### PR TITLE
Restoring html-tokenizer to original

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "backbone": "^1.1.2",
     "backbone.native": "~1.0.0",
     "data-set": "^4.0.0",
-    "html-tokenizer": "https://github.com/MattDeeg/html-tokenizer/archive/master.tar.gz",
+    "html-tokenizer": "^1.4.4",
     "json-loader": "^0.5.2",
     "ractive": "^0.6.1",
     "underscore": "^1.7.0",


### PR DESCRIPTION
Pull request has been merged, so there's no need for the forked version