### PR TITLE
Enabling use of pre-compiler without webpack

### DIFF
--- a/precompile/tungsten_template/index.js
+++ b/precompile/tungsten_template/index.js
@@ -20,7 +20,7 @@ var utils = require('./shared_utils');
  */
 module.exports = function(contents, templateFileExt, useWebpack) {
   templateFileExt = typeof templateFileExt !== 'undefined' ? templateFileExt : 'mustache';
-  useWebpack = typeof useWebpack !== 'undefined' ? useWebpack : false;
+  useWebpack = typeof useWebpack !== 'undefined' ? useWebpack : true;
   if (useWebpack) {
     this.cacheable();
   }

--- a/precompile/tungsten_template/index.js
+++ b/precompile/tungsten_template/index.js
@@ -18,8 +18,12 @@ var utils = require('./shared_utils');
  * Compiles given templates
  * @param  {String} contents Root directory of templates to get stripped off partials
  */
-module.exports = function(contents) {
-  this.cacheable();
+module.exports = function(contents, templateFileExt, useWebpack) {
+  templateFileExt = typeof templateFileExt !== 'undefined' ? templateFileExt : 'mustache';
+  useWebpack = typeof useWebpack !== 'undefined' ? useWebpack : false;
+  if (useWebpack) {
+    this.cacheable();
+  }
   var parsedTemplate = utils.compileTemplate(contents, module.src);
   var partials = utils.findPartials(parsedTemplate);
   utils.handleDynamicComments(parsedTemplate);
@@ -34,7 +38,7 @@ module.exports = function(contents) {
   if (_.size(partials) > 0) {
     output += 'template.setPartials({';
     output += _.map(partials, function(v, partial) {
-      return '"' + partial + '":require("./' + partial + '.mustache")';
+      return '"' + partial + '":require("./' + partial + '.' + templateFileExt + '")';
     }).join(',');
     output += '});';
   }


### PR DESCRIPTION
I'm trying to use the tungsten pre-compiler just in a grunt task, without webpack, and "this.cacheable()" is specifically for webpack. Also allowing different file extensions for template partials.