### PR TITLE
Revert "Enabling use of pre-compiler without webpack"

### DIFF
--- a/precompile/tungsten_template/index.js
+++ b/precompile/tungsten_template/index.js
@@ -18,12 +18,8 @@ var utils = require('./shared_utils');
  * Compiles given templates
  * @param  {String} contents Root directory of templates to get stripped off partials
  */
-module.exports = function(contents, templateFileExt, useWebpack) {
-  templateFileExt = typeof templateFileExt !== 'undefined' ? templateFileExt : 'mustache';
-  useWebpack = typeof useWebpack !== 'undefined' ? useWebpack : true;
-  if (useWebpack) {
-    this.cacheable();
-  }
+module.exports = function(contents) {
+  this.cacheable();
   var parsedTemplate = utils.compileTemplate(contents, module.src);
   var partials = utils.findPartials(parsedTemplate);
   utils.handleDynamicComments(parsedTemplate);
@@ -38,7 +34,7 @@ module.exports = function(contents, templateFileExt, useWebpack) {
   if (_.size(partials) > 0) {
     output += 'template.setPartials({';
     output += _.map(partials, function(v, partial) {
-      return '"' + partial + '":require("./' + partial + '.' + templateFileExt + '")';
+      return '"' + partial + '":require("./' + partial + '.mustache")';
     }).join(',');
     output += '});';
   }


### PR DESCRIPTION
Reverts wayfair/tungstenjs#35; we're going to refactor this so there's a separate compiler for non-webpack builds.