### PR TITLE
Collection fix

### DIFF
--- a/adaptors/backbone/backbone_nested.js
+++ b/adaptors/backbone/backbone_nested.js
@@ -201,7 +201,10 @@ exports.setNestedModel = function(Model) {
       }
 
       options._parent = this;
-
+      // Since this is a relation for a model, unset any collection option that might be passed through
+      if (options.collection) {
+        options.collection = null;
+      }
       val = new this.relations[attr](val, options);
       val.parent = this;
       val.parentProp = attr;

--- a/adaptors/backbone/context_adaptor.js
+++ b/adaptors/backbone/context_adaptor.js
@@ -42,8 +42,8 @@ var initialize = function(view, parentContext) {
   if (view == null) {
     view = {};
   }
-  if (!parentContext && (view.collection || view.parent)) {
-    this.parent = new Context(view.collection || view.parent);
+  if (!parentContext && (view.parent || view.collection)) {
+    this.parent = new Context(view.parent || view.collection);
   } else {
     this.parent = parentContext;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
Given the structure Collection1 => Model1 => Model2, Model1.collection is correctly set to Collection1 and Model2.parent is correctly set to Model1, but Model2 additionally has collection set to Collection1.
This causes the context back-fill to incorrectly bypass Model1.
This is a two part fix..
1: prevent collection from being set on models that are not directly in a collection
2: change order of preference during context lookups to prefer view.parent over view.collection