### PR TITLE
Debugger changes: Allow for non-serializable objects

### DIFF
--- a/adaptors/backbone/base_model.js
+++ b/adaptors/backbone/base_model.js
@@ -121,26 +121,55 @@ var BaseModel = Backbone.Model.extend({
    */
   getPropertiesArray: function() {
     var properties = [];
-    var relations = this.relations;
+    var relations = _.result(this, 'relations') || {};
+    var derived = _.result(this, 'derived') || {};
+
+    var isEditable = function(value) {
+      if (!_.isObject(value)) {
+        return true;
+      } else if (_.isArray(value)) {
+        var result = true;
+        _.each(value, function(i) {
+          result = result && isEditable(i);
+        });
+        return result;
+      } else {
+        try {
+          JSON.stringify(value);
+          return true;
+        } catch (ex) {
+          return false;
+        }
+      }
+    };
+
     _.each(this.attributes, function(value, key) {
+      var prop;
       if (relations && relations[key]) {
-        properties.push({
+        prop = {
           key: key,
           data: {
             isRelation: true,
             name: value.getDebugName()
           }
-        });
+        };
       } else {
-        properties.push({
+        prop = {
           key: key,
           data: {
+            isDerived: derived[key],
+            isEditable: isEditable(value),
             isEditing: false,
             value: value
           }
-        });
+        };
+
+        prop.data.displayValue = prop.data.isEditable ? JSON.stringify(value) : Object.prototype.toString.call(value);
       }
+      properties.push(prop);
     });
+
+    properties = _.sortBy(properties, 'key');
 
     return properties;
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",

--- a/src/debug/panel/info_panels/model/_properties_panel.template
+++ b/src/debug/panel/info_panels/model/_properties_panel.template
@@ -8,17 +8,29 @@
           <div class="body">
               <div class="section expanded">
                   <ol data-property-key="" class="properties properties-tree monospace">
-                    <% _.each(panel.model.modelProperties, function(prop) { %>
-                    <li data-property-name="attributes" class="js-model-property" data-key="<%= prop.key %>">
+                    <% _.each(panel.model.modelProperties, function(prop) {
+                        var wrapperClassName = '';
+                        var clickableClassName = ''
+                        var isEditable = prop.data.isEditable && !prop.data.isDerived;
+                        if (isEditable) {
+                          clickableClassName = 'clickable-property';
+                          wrapperClassName += 'js-model-property';
+                        }
+
+                        if (prop.data.isDerived) {
+                          wrapperClassName += ' derived_property';
+                        }
+                      %>
+                    <li data-property-name="attributes" class="<%= wrapperClassName %>" data-key="<%= prop.key %>">
                         <span class="name"><%= prop.key %></span><span class="separator">: </span>
                         <% if (prop.data.isRelation) { %>
                           <span class="value console-formatted-undefined clickable-property js-model-list-item" data-id="<%= prop.data.name %>"> <%= prop.data.name %> </span>
                         <% } else { %>
-                          <span class="value console-formatted-undefined clickable-property">
+                          <span class="value console-formatted-undefined <%= clickableClassName %>">
                             <% if (prop.data.isEditing) { %>
-                              <input type="text" value="<%- JSON.stringify(prop.data.value) %>" autofocus="true" class="js-model-property-value">
+                              <input type="text" value="<%- prop.data.displayValue %>" autofocus="true" class="js-model-property-value">
                             <% } else { %>
-                              <span><%- JSON.stringify(prop.data.value) %></span>
+                              <span><%- prop.data.displayValue %></span>
                             <% } %>
                           </span>
                         <% } %>


### PR DESCRIPTION
Currently putting an object that isn't able to be stringified into JSON produces an error for the entire panel render. This change falls back to an uneditable, but readable version using Object.toString.

Additionally, editing a derived property can cause some undesirable oddness, so this also sets derived properties as un-editable.