### PR TITLE
Add undefined check in undelegate

### DIFF
--- a/adaptors/backbone/base_view.js
+++ b/adaptors/backbone/base_view.js
@@ -385,7 +385,9 @@ var BaseView = Backbone.View.extend({
     // Uses array created in delegateEvents to unbind events
     if (this.eventsToRemove) {
       for (var i = 0; i < this.eventsToRemove.length; i++) {
-        tungsten.unbindEvent(this.eventsToRemove[i]);
+        if (typeof this.eventsToRemove[i] !== 'undefined') {
+          tungsten.unbindEvent(this.eventsToRemove[i]);
+        }
       }
       this.eventsToRemove = null;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
If something goes wrong then eventsToRemove[i] is still undefined.  This fixes an ie8 bug.