### PR TITLE
Transfer listeners

### DIFF
--- a/adaptors/backbone/base_view.js
+++ b/adaptors/backbone/base_view.js
@@ -432,9 +432,39 @@ var BaseView = Backbone.View.extend({
     // Track if anything has changed in order to trigger a render
     if (newModel !== this.model) {
       // If the model has changed, change listener to new model
-      this.stopListening(this.model);
+      var currentModel = this.model;
+      var currentModelListeners = currentModel.__listeners || currentModel._listeners;
+      if (currentModelListeners) {
+        var oldListenId = currentModel._listenId;
+        var newListenId = newModel._listenId;
+        _.each(currentModelListeners, function(data) {
+          data.obj = newModel;
+          data.objId = newListenId;
+          // Move listener to new listenId and clear previous
+          data.listeningTo[newListenId] = data.listeningTo[oldListenId];
+          data.listeningTo[oldListenId] = null;
+        });
+      }
+      newModel.__listeners = newModel._listeners;
+      newModel._listeners = currentModelListeners;
+      // Move all events and change any old model contexts to new model
+      var currentModelEvents = currentModel.__events || currentModel._events;
+      _.each(currentModelEvents, function(bound) {
+        for (var i = bound.length; i--;) {
+          if (bound[i].ctx === currentModel) {
+            bound[i].ctx = newModel;
+          }
+        }
+      });
+      newModel.__events = newModel._events;
+      newModel._events = currentModelEvents;
+
+      setTimeout(function() {
+        // Clear stored listeners
+        newModel.__listeners = null;
+        newModel.__events = null;
+      }, 0);
       this.model = newModel;
-      this.initializeRenderListener(newModel);
     }
     this.render();
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
When a parent model is reset such that child models are changed out, but the view structure is maintained, the view's have update called on them and their models swapped out.
The issue arrises when the view had called this.model.on() or this.listenTo(this.model). These listeners are not maintained after update is called since the object that was listened to is gone.
This change maintains those events and allows for things such as a collection sort event, where models would be swapped between views, by temporarily storing the pre-update listeners and events on secondary parameters.