### PR TITLE
Template overlap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
While attaching a view to a template, we replace bits of the template with a Widget. The problem is that we weren't completely cloning the template so shared templates could conceivably have Widget from multiple views attached, which is wrong.

The first commit on this branch added failing tests (not sure why it's showing as a pass), which are resolved by the second commit.