### PR TITLE
Fix for handling cases where widget updates create a new element

### DIFF
--- a/adaptors/ampersand/base_view.js
+++ b/adaptors/ampersand/base_view.js
@@ -31,10 +31,6 @@ var BaseView = AmpersandView.extend({
     }
     this.options = options || {};
 
-    // VTree is passable as an option if we are transitioning in from a different view
-    if (this.options.vtree) {
-      this.vtree = this.options.vtree;
-    }
     // Template object
     if (this.options.template) {
       this.compiledTemplate = this.options.template;
@@ -408,7 +404,15 @@ var BaseView = AmpersandView.extend({
     // defaults to an empty object for context so that our view render won't fail
     var serializedModel = this.context || this.serialize();
     var initialTree = this.vtree || this.compiledTemplate.toVdom(this.serialize(), true);
-    this.vtree = tungsten.updateTree(this.el, initialTree, this.compiledTemplate.toVdom(serializedModel));
+    var result = tungsten.updateTree(this.el, initialTree, this.compiledTemplate.toVdom(serializedModel));
+    this.vtree = result.vtree;
+    if (result.elem !== this.el) {
+      // Needed due to handling of the 'el' property in View constructor
+      var self = this;
+      setTimeout(function() {
+        self.el = result.elem;
+      }, 0);
+    }
 
     // Clear any passed context
     this.context = null;

--- a/adaptors/backbone/base_view.js
+++ b/adaptors/backbone/base_view.js
@@ -406,7 +406,11 @@ var BaseView = Backbone.View.extend({
     // defaults to an empty object for context so that our view render won't fail
     var serializedModel = this.context || this.serialize();
     var initialTree = this.vtree || this.compiledTemplate.toVdom(this.serialize(), true);
-    this.vtree = tungsten.updateTree(this.el, initialTree, this.compiledTemplate.toVdom(serializedModel));
+    var result = tungsten.updateTree(this.el, initialTree, this.compiledTemplate.toVdom(serializedModel));
+    this.vtree = result.vtree;
+    if (result.elem !== this.el) {
+      this.setElement(result.elem);
+    }
 
     // Clear any passed context
     this.context = null;

--- a/src/tungsten.js
+++ b/src/tungsten.js
@@ -38,10 +38,13 @@ exports.unbindEvent = globalEvents.unbindVirtualEvent;
 
 function updateTree(container, initialTree, newTree) {
   var patch = vdom.diff(initialTree, newTree);
-  vdom.patch(container, patch);
+  var elem = vdom.patch(container, patch);
   // Repool VDom used in initial tree
   initialTree.recycle();
-  return newTree;
+  return {
+    vtree: newTree,
+    elem: elem
+  };
 }
 
 /* develblock:start */

--- a/test/src/tungsten_spec.js
+++ b/test/src/tungsten_spec.js
@@ -182,14 +182,16 @@ describe('tungsten.js public API', function() {
       };
       var newTree = {};
       var patch = {};
+      var elem = {};
       spyOn(vdom, 'diff').and.returnValue(patch);
-      spyOn(vdom, 'patch');
+      spyOn(vdom, 'patch').and.returnValue(elem);
       var result = tungsten.updateTree(container, initialTree, newTree);
 
       jasmineExpect(vdom.diff).toHaveBeenCalledWith(initialTree, newTree);
       jasmineExpect(vdom.patch).toHaveBeenCalledWith(container, patch);
       jasmineExpect(initialTree.recycle).toHaveBeenCalled();
-      expect(result).to.equal(newTree);
+      expect(result.vtree).to.equal(newTree);
+      expect(result.elem).to.equal(elem);
     });
   });
 });


### PR DESCRIPTION
There was an issue where if .update() was called for a widget where the tag names did not match, the new view received a detached DOM node and was no longer able to function.

For example, given the template
```html
{{#a}}<div class="js-a">First</div>{{/a}}
{{^a}}<span class="js-b">Second</span>{{/a}}
```

If we set 'a' from true to false, a view for 'js-b' would be constructed, passing the existing div as the element to bind to. Then render is called, but since virtual-dom can't change a div to a span, it removes the div and returns the span from its patch function. That resulting element needs to be passed back out to the view that called updateTree so that it can change its element to the correct one.