### PR TITLE
Fixing rendering for widgets embedded on the stack for DOM/HTML string

### DIFF
--- a/src/template/stacks/dom.js
+++ b/src/template/stacks/dom.js
@@ -2,6 +2,8 @@
 
 var _ = require('underscore');
 var DefaultStack = require('./default');
+var virtualDomImplementation = require('../../vdom/virtual_dom_implementation');
+var isWidget = virtualDomImplementation.isWidget;
 var htmlParser = require('../html_parser');
 
 function applyProperties(node, props) {
@@ -57,7 +59,9 @@ DomStack.prototype.processObject = function(obj) {
 };
 
 DomStack.prototype.createObject = function(obj, options) {
-  if (typeof obj === 'string' && options && options.parse) {
+  if (isWidget(obj)) {
+    obj.template._iterate(null, obj.model, null, null, this);
+  } else if (typeof obj === 'string' && options && options.parse) {
     // Naive check to avoid parsing if value contains nothing HTML-ish or HTML-entity-ish
     if (obj.indexOf('<') > -1 || obj.indexOf('&') > -1) {
       htmlParser(obj, this);

--- a/src/template/stacks/html_string.js
+++ b/src/template/stacks/html_string.js
@@ -62,7 +62,7 @@ HtmlStringStack.prototype.processObject = function(obj) {
 
 HtmlStringStack.prototype.createObject = function(obj, options) {
   if (isWidget(obj)) {
-    obj.template._render(null, obj.model, null, null, this);
+    obj.template._iterate(null, obj.model, null, null, this);
   } else if (typeof obj === 'string' && options && options.escape) {
     this._closeElem(escapeString(obj));
   } else {

--- a/src/template/template.js
+++ b/src/template/template.js
@@ -40,7 +40,8 @@ Template.prototype.register = function(partialName) {
   registeredPartials[partialName] = this.templateObj;
 };
 
-Template.prototype._iterate = function(template, context, view, partials, stack) {
+Template.prototype._iterate = function(template, data, view, partials, stack) {
+  var context = (data && data.constructor && data instanceof Context) ? data : new Context(data);
   ractiveAdaptor.render(
     stack,
     template || this.templateObj,
@@ -50,7 +51,6 @@ Template.prototype._iterate = function(template, context, view, partials, stack)
   );
 };
 Template.prototype._render = function(template, data, view, partials, stack) {
-  var context = (data && data.constructor && data instanceof Context) ? data : new Context(data);
   this._iterate(template, context, view, partials, stack);
   return stack.getOutput();
 };

--- a/src/template/template.js
+++ b/src/template/template.js
@@ -51,7 +51,7 @@ Template.prototype._iterate = function(template, data, view, partials, stack) {
   );
 };
 Template.prototype._render = function(template, data, view, partials, stack) {
-  this._iterate(template, context, view, partials, stack);
+  this._iterate(template, data, view, partials, stack);
   return stack.getOutput();
 };
 


### PR DESCRIPTION
the DOM stack was missing the widget check and HTML String was using _render rather than _iterate so it was clearing the stack after rendering the component, which was throwing warnings. This corrects the behaviors of both