### PR TITLE
Adding empty to the serialize hash so that empty inputs are serialized

### DIFF
--- a/src/event/handlers/submit_data_events.js
+++ b/src/event/handlers/submit_data_events.js
@@ -13,7 +13,7 @@ function getHandlers(method) {
 
   var submitHandler = function(evt) {
     var form = evt.target;
-    var data = serialize(form, { hash: true });
+    var data = serialize(form, { hash: true, empty: true });
     method(evt, _.extend(data, submit));
   };
 


### PR DESCRIPTION
Currently, if an input's value is left empty, it isn't part of the data that is serialized, which caused issues for implementations using this event to update the model for validation