### PR TITLE
Template abstraction performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",

--- a/perf_test.js
+++ b/perf_test.js
@@ -1,0 +1,61 @@
+var _ = require('underscore');
+require('./test/environment');
+var Context = require('./src/template/template_context');
+var compiler = require('./precompile/tungsten_template/inline');
+var Timer = require('./src/debug/timer');
+
+// Using simplified lookup functions
+Context.setAdapterFunctions({
+  initialize: function(view, parentContext) {
+    if (view == null) {
+      view = {};
+    }
+    this.parent = parentContext;
+  },
+  lookupValue: function(view, name) {
+    var value = null;
+    if (view && view[name] != null) {
+      value = view[name];
+    }
+
+    if (typeof value === 'function') {
+      value = value.call(view);
+    }
+    return value;
+  }
+});
+
+function getTemplate(templateStr, partials) {
+  return compiler(templateStr || '', partials || {});
+}
+
+// Sample template with most Mustache features
+// Section - Array
+// Partial
+// Static attribute
+// Dynamic attribute
+// Escaped text
+// Unescaped text with HTML
+var template = getTemplate('<select>\r\n{{#options}}  {{> option}}{{/option}}</select>', {
+  option: '<option value="{{index}}" {{#even}}class="even"{{/even}} {{^even}}class="odd "{{/even}}>{{text}} {{nothing}} {{{raw_html}}} {{{raw_text}}}</option>\r\n'
+});
+var data = {
+  raw_html: '<b>test &amp;</b>',
+  raw_text: 'test',
+  nothing: undefined,
+  options: _.map(new Array(1000), function(v, i) {
+    return {
+      index: i,
+      text: '"' + i + '"',
+      even: i % 2 === 0
+    };
+  })
+};
+
+// Average render time over ten runs
+// Using timer to grab any other timer data that is set
+var t = new Timer('perf_run');
+for (var i = 0; i < 10; i++) {
+  template.toVdom(data);
+  t.log('rendered');
+}

--- a/src/debug/index.js
+++ b/src/debug/index.js
@@ -5,5 +5,6 @@ module.exports = {
   panel: require('./window_manager'),
   vtreeToString: require('./vtree_to_string'),
   diffVtreeAndElem: require('./diff_dom_and_vdom'),
-  diff: require('./text_diff')
+  diff: require('./text_diff'),
+  timer: require('./timer')
 };

--- a/src/debug/timer.js
+++ b/src/debug/timer.js
@@ -1,0 +1,117 @@
+'use strict';
+
+var _ = require('underscore');
+var process = require('process');
+var logger = require('../utils/logger');
+var now;
+/**
+ * Use the highest resolution timing that the environment provides
+ */
+if (process && typeof process.hrtime === 'function') {
+  // node
+  now = function() {
+    var time = process.hrtime();
+    // Convert seconds and nanoseconds into high-resolution milliseconds
+    return (time[0] * 1000) + (time[1] / 1e6);
+  };
+} else if (window && window.performance && typeof window.performance.now === 'function') {
+  // modern browser
+  now = window.performance.now.bind(window.performance);
+} else {
+  // everything else
+  now = Date.now.bind(Date);
+}
+
+/**
+ * Calculates the time offset for the given timer
+ *
+ * @param  {Timer} timer Timer to check
+ *
+ * @return {Number}      Time offset
+ */
+function offset(timer) {
+  return timer.adjust + now() - timer.startTime;
+}
+
+/**
+ * Timing helper to performance test functionality
+ *
+ * @param {String}  name         Name of this time for tracking purposes
+ * @param {Boolean} absoluteTime Whether to use absolute times or relative
+ */
+var Timer = function(name, absoluteTime) {
+  this.name = name;
+  this.startTime = now();
+  this.absoluteTime = !!absoluteTime;
+  this.adjust = 0;
+  this.running = true;
+};
+
+/**
+ * Log a stat point
+ *
+ * @param  {String} label Name to log as
+ */
+Timer.prototype.log = function(label) {
+  if (!this.running) {
+    return;
+  }
+  logStat(this.name + '.' + label, offset(this));
+  if (!this.absoluteTime) {
+    this.startTime = now();
+  }
+};
+
+/**
+ * Pause the timer
+ */
+Timer.prototype.pause = function() {
+  this.adjust = now() - this.startTime;
+  this.running = false;
+};
+
+/**
+ * Unpause the timer
+ */
+Timer.prototype.unpause = function() {
+  this.startTime = now();
+  this.running = true;
+};
+
+/** @type {Object} Track logged metrics to average later */
+var statsTracker = {};
+/** @type {Number} Timeout for printing stats */
+var statsTimer;
+
+/**
+ * Add data point to stats
+ *
+ * @param  {String} stat  Full name of the stat
+ * @param  {Number} value Run time to track
+ */
+function logStat(stat, value) {
+  if (!statsTracker[stat]) {
+    statsTracker[stat] = [];
+  }
+  statsTracker[stat].push(value);
+  clearTimeout(statsTimer);
+  statsTimer = setTimeout(printStats, 100);
+}
+
+/**
+ * Output the average stats to logger
+ */
+function printStats() {
+  _.each(statsTracker, function(vals, stat) {
+    var numStats = vals.length;
+    var total = _.reduce(vals, function(memo, num) {
+      return memo + num;
+    }, 0);
+    var avg = parseFloat(total / numStats).toFixed(4) + 'ms';
+    var printableTotal = parseFloat(total).toFixed(4) + 'ms';
+    logger.log(stat + ': ' + avg + ' (' + printableTotal + ' / ' + numStats + ')');
+  });
+  statsTracker = {};
+}
+
+module.exports = Timer;

--- a/src/template/html_parser.js
+++ b/src/template/html_parser.js
@@ -5,25 +5,32 @@ var entityMap = require('html-tokenizer/entity-map');
 // @TODO examine other tokenizers or parsers
 var Parser = require('html-tokenizer/parser');
 
-module.exports = function(html, stack) {
-  var _stack = stack || new DefaultStack(true);
+var defaultStack = new DefaultStack(true);
+var _stack;
+var parser = new Parser({
+  entities: entityMap
+});
+parser.on('open',  function(name, attributes) {
+  _stack.openElement(name, attributes);
+});
+parser.on('comment', function(text) {
+  _stack.createComment(text);
+});
+parser.on('text', function(text) {
+  _stack.createObject(text);
+});
+parser.on('close', function() {
+  var el = _stack.peek();
+  _stack.closeElement(el);
+});
 
-  var parser = new Parser({
-    entities: entityMap
-  });
-  parser.on('open',  function(name, attributes) {
-    _stack.openElement(name, attributes);
-  });
-  parser.on('comment', function(text) {
-    _stack.createComment(text);
-  });
-  parser.on('text', function(text) {
-    _stack.createObject(text);
-  });
-  parser.on('close', function() {
-    var el = _stack.peek();
-    _stack.closeElement(el);
-  });
+module.exports = function(html, stack) {
+  if (stack) {
+    _stack = stack;
+  } else {
+    defaultStack.clear();
+    _stack = defaultStack;
+  }
 
   parser.parse(html);
 


### PR DESCRIPTION
This fixes the majority of the performance issues that were introduced by the template abstraction merge. As identified earlier today.

I created a test template along with a performance timer and came up with the following measurements

Before Template Abstraction (based on commit 2591ee60e614f3059ba346fe66c1ad54c4e2bc18):
```perf_run.rendered: 94.9150ms (949.1502ms / 10)```
Template Abstraction (current master 47362871e7f58a05904df9283870fde06c82ce41)
```perf_run.rendered: 2609.7290ms (26097.2904ms / 10)```

Timers were used to track the performance hit back to the html_parser module, meaning that the issue primarily affected rendering of triple curly data with HTML content as well as dynamic attributes. Parser was being constructed inside to allow various stacks to be passed in, but this was easily adjusted to be constructed as it was previously and use an external variable for the stack. As a result, this PR returns performance to the original state:
```perf_run.rendered: 95.8699ms (958.6990ms / 10)```