### PR TITLE
Textarea value fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",

--- a/precompile/tungsten_template/index.js
+++ b/precompile/tungsten_template/index.js
@@ -22,8 +22,6 @@ module.exports = function(contents) {
   this.cacheable();
   var parsedTemplate = utils.compileTemplate(contents, module.src);
   var partials = utils.findPartials(parsedTemplate);
-  utils.handleSvg(parsedTemplate);
-  utils.handleDynamicComments(parsedTemplate);
   var template = JSON.stringify(parsedTemplate);
 
   var templatePath = path.relative(path.dirname(module.dest), __dirname + '/template');

--- a/precompile/tungsten_template/inline.js
+++ b/precompile/tungsten_template/inline.js
@@ -36,7 +36,6 @@ if (require && require.extensions) {
 
 function compile(contents, partials) {
   var parsedTemplate = utils.compileTemplate(contents, module.src);
-  utils.handleDynamicComments(parsedTemplate);
   var template = new Template(parsedTemplate);
 
   if (_.size(partials) > 0) {

--- a/precompile/tungsten_template/shared_utils.js
+++ b/precompile/tungsten_template/shared_utils.js
@@ -83,8 +83,44 @@ module.exports.compileTemplate = function(contents, srcFile) {
     logger.error('Unable to parse ' + (srcFile || contents));
     throw new Error('Compilation error: ' + ex.message);
   }
+  module.exports.handleSvg(parsed.t);
+  module.exports.handleDynamicComments(parsed.t);
+  module.exports.handleTextareas(parsed.t);
 
   return parsed.t;
+};
+
+module.exports.handleTextareas = function(template) {
+  if (typeof template === 'string' || typeof template === 'undefined') {
+    // String or undefined means we've bottomed out
+    return;
+  } else if (template instanceof Array) {
+    // Arrays need mapping over
+    for (var i = 0; i < template.length; i++) {
+      module.exports.handleTextareas(template[i]);
+    }
+    return;
+  }
+
+  switch (template.t) {
+
+    case ractiveTypes.SECTION:
+      module.exports.handleTextareas(template.f);
+      break;
+    case ractiveTypes.ELEMENT:
+      if (template.e.toLowerCase() === 'textarea') {
+        if (!template.a) {
+          template.a = {};
+        }
+        template.a.value = template.f;
+        template.f = [];
+      } else {
+        module.exports.handleTextareas(template.f);
+      }
+      break;
+  }
+
+  return;
 };
 
 module.exports.handleSvg = function(template, inSVG) {

--- a/src/template/stacks/html_string.js
+++ b/src/template/stacks/html_string.js
@@ -38,8 +38,17 @@ function escapeString(str) {
 HtmlStringStack.prototype.processObject = function(obj) {
   if (obj.type === 'node') {
     var htmlStr = '<' + obj.tagName;
+    // For HTML strings, a textarea's value is defined by it's childNode
+    // For everything else, it uses the value property
+    // Since .toString is used least by far, add the expense here
+    if (obj.tagName.toLowerCase() === 'textarea' && obj.properties.attributes && obj.properties.attributes.value) {
+      obj.children = [obj.properties.attributes.value];
+      obj.properties.attributes.value = null;
+    }
     _.each(obj.properties.attributes, function(value, name) {
-      htmlStr += ' ' + name + '="' + value + '"';
+      if (value != null) {
+        htmlStr += ' ' + name + '="' + value + '"';
+      }
     });
     if (obj.children.length) {
       htmlStr += '>';

--- a/test/precompile/shared_utils_spec.js
+++ b/test/precompile/shared_utils_spec.js
@@ -55,12 +55,6 @@ describe('shared_utils.js public api', function() {
       var template = sharedUtils.compileTemplate('<!--{{a}}-->');
       expect(template).to.deep.equal([{
         t: 9,
-        c: '{{a}}'
-      }]);
-
-      sharedUtils.handleDynamicComments(template);
-      expect(template).to.deep.equal([{
-        t: 9,
         c: [{
           t: 2,
           r: 'a'

--- a/test/src/template/template_spec.js
+++ b/test/src/template/template_spec.js
@@ -153,3 +153,23 @@ var specs = require('./get_template_spec_for_renderer');
 specs(toHtmlViaString);
 specs(toHtmlViaDom);
 specs(toHtmlViaVdom);
+
+describe('textarea value sets', function() {
+  var TEST_VALUE = 'testvalue';
+  var template = compiler('<textarea>{{value}}</textarea>');
+  it('should render to vdom with the value property', function() {
+    var output = template.toVdom({value: TEST_VALUE});
+    expect(output.children.length).to.equal(0);
+    expect(output.properties.value).to.equal(TEST_VALUE);
+  });
+  it('should render to dom with the value property', function() {
+    var output = template.toDom({value: TEST_VALUE});
+    expect(output.tagName.toLowerCase()).to.equal('textarea');
+    expect(output.childNodes.length).to.equal(0);
+    expect(output.value).to.equal(TEST_VALUE);
+  });
+  it('should render to string with a childNode', function() {
+    var output = template.toString({value: TEST_VALUE});
+    expect(output).to.equal('<textarea>' + TEST_VALUE + '</textarea>');
+  });
+});


### PR DESCRIPTION
In HTML textarea's value is handled by childNode, but for DOM/VDOM, it should use the value property instead. Since String output is the least used and most flexible output, the template compiler was adjusted to move the child array of any textarea node to its value property. During toString compilation, the value property is moved back to children so that rendering occurs as expected.

Also adjusted the precompiler to move the functions that adjust the template tree internal to compileTemplates so that all compilers are adjusted equally as the inline compiler was missing the handleSvg adjustment.