### PR TITLE
Switching from html-tokenizer to htmlparser2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "backbone.native": "~1.0.0",
     "data-set": "^4.0.0",
     "form-serialize": "^0.6.0",
-    "html-tokenizer": "^1.4.4",
+    "htmlparser2": "^3.8.3",
     "jsdom": "^6.5.0",
     "json-loader": "^0.5.2",
     "ractive": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.6.1",
+  "version": "0.7.0-0",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "chai": "^2.2.0",
     "coveralls": "^2.11.4",
+    "entities": "^1.1.1",
     "eslint": "1.0.0-rc-1",
     "express": "^4.13.3",
     "glob": "^4.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.7.0-0",
+  "version": "0.7.0",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",

--- a/precompile/tungsten_debug/index.js
+++ b/precompile/tungsten_debug/index.js
@@ -10,7 +10,7 @@ module.exports = function(contents) {
     var isPanel = this.resourcePath.indexOf('/debug/panel/info_panels') > -1;
     isPanel = isPanel || this.resourcePath.indexOf('\\debug\\panel\\info_panels') > -1;
     var templateVar = isPanel ? 'panel' : 'w';
-    return 'module.exports=' + _.template(contents, {
+    return 'var _=require("underscore");module.exports=' + _.template(contents, {
       variable: templateVar
     }).source + ';';
   }

--- a/src/debug/to_string_utils.js
+++ b/src/debug/to_string_utils.js
@@ -21,7 +21,8 @@ module.exports.NODE_TYPES = {
 
 
 var entityMap = {};
-_.each(require('html-tokenizer/entity-map'), function(charCode, name) {
+// entities is the package used by htmlparser2
+_.each(require('entities/maps/entities.json'), function(charCode, name) {
   // Ignore whitespace only characters
   if (!/\s/.test(charCode)) {
     entityMap[charCode.charCodeAt(0)] = '&' + name.toLowerCase() + ';';

--- a/src/template/html_parser.js
+++ b/src/template/html_parser.js
@@ -1,28 +1,25 @@
 'use strict';
 
 var DefaultStack = require('./stacks/default');
-var entityMap = require('html-tokenizer/entity-map');
-// @TODO examine other tokenizers or parsers
-var Parser = require('html-tokenizer/parser');
+var Parser = require('htmlparser2').Parser;
 
 var defaultStack = new DefaultStack(true);
 var _stack;
 var parser = new Parser({
-  entities: entityMap
-});
-parser.on('open',  function(name, attributes) {
-  _stack.openElement(name, attributes);
-});
-parser.on('comment', function(text) {
-  _stack.createComment(text);
-});
-parser.on('text', function(text) {
-  _stack.createObject(text);
-});
-parser.on('close', function() {
-  var el = _stack.peek();
-  _stack.closeElement(el);
-});
+  onopentag: function(name, attributes) {
+    _stack.openElement(name, attributes);
+  },
+  oncomment: function(text) {
+    _stack.createComment(text);
+  },
+  ontext: function(text) {
+    _stack.createObject(text);
+  },
+  onclosetag: function() {
+    var el = _stack.peek();
+    _stack.closeElement(el);
+  }
+}, {decodeEntities: true});
 
 module.exports = function(html, stack) {
   if (stack) {
@@ -32,7 +29,7 @@ module.exports = function(html, stack) {
     _stack = defaultStack;
   }
 
-  parser.parse(html);
+  parser.end(html);
 
   if (!stack) {
     return _stack.getOutput();

--- a/src/template/html_parser.js
+++ b/src/template/html_parser.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var DefaultStack = require('./stacks/default');
-var Parser = require('htmlparser2').Parser;
+var Parser = require('htmlparser2/lib/Parser');
 
 var defaultStack = new DefaultStack(true);
 var _stack;

--- a/test/adaptors/backbone/base_model_spec.js
+++ b/test/adaptors/backbone/base_model_spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var _ = require('underscore');
 var BackboneAdaptor = require('../../../adaptors/backbone');
 var BaseModel = BackboneAdaptor.Model;
 var BaseCollection = BackboneAdaptor.Collection;


### PR DESCRIPTION
Ran some benchmarks and determined that htmlparser2 is ~14x faster than html-tokenizer based on the tests in the htmlparser-benchmark package.

htmlparser2    : 4.26190 ms/file ± 2.79681
html-tokenizer : 55.5469 ms/file ± 442.809

Fixed a few "_ is not defined" errors encountered during testing