### PR TITLE
Add unit tests for template abstraction

### DIFF
--- a/test/src/template/html_helpers_spec.js
+++ b/test/src/template/html_helpers_spec.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var htmlHelpers = require('../../../src/template/html_helpers');
+
+describe('html_helpers.js public API', function() {
+  describe('isValidChild', function() {
+    it('should be a function', function() {
+      expect(htmlHelpers.validation.isValidChild).to.be.a('function');
+    });
+    it('should check for a valid child', function() {
+      expect(htmlHelpers.validation.isValidChild('li', 'li')).to.equal(false);
+    });
+    it('should check for an invalid child', function() {
+      expect(htmlHelpers.validation.isValidChild('li', 'ul')).to.equal(true);
+    });
+    it('should return the opposite of impliedCloseTag', function() {
+      var isValidChild = htmlHelpers.validation.isValidChild('li', 'ul');
+      var impliedCloseTag = htmlHelpers.validation.impliedCloseTag('li', 'ul');
+      expect(isValidChild).to.equal(!impliedCloseTag);
+    });
+  });
+  describe('impliedCloseTag', function() {
+    it('should be a function', function() {
+      expect(htmlHelpers.validation.impliedCloseTag).to.be.a('function');
+    });
+    it('should check correctly for valid omission of a close tag', function() {
+      expect(htmlHelpers.validation.impliedCloseTag('li', 'li')).to.equal(true);
+    });
+    it('should check correctly for invalid omission of a close tag', function() {
+      expect(htmlHelpers.validation.impliedCloseTag('li', 'ul')).to.equal(false);
+    });
+  });
+});

--- a/test/src/template/process_properties_spec.js
+++ b/test/src/template/process_properties_spec.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var processProperties = require('../../../src/template/process_properties');
+var Autofocus = require('../../../src/template/hooks/autofocus');
+
+describe('process_properties.js public API', function() {
+  describe('processProperties', function() {
+    it('should be a function', function() {
+      expect(processProperties).to.be.a('function');
+    });
+    it('should treat all properties of elements with namespaces (usually SVG) as attributes', function() {
+      var result = processProperties({namespace: 'Test', label: 'label', class: 'js-test'});
+      expect(result).to.be.a('object');
+      expect(result.namespace).to.equal('Test');
+      expect(result.attributes).to.deep.equal({namespace: undefined, label: 'label', class: 'js-test'});
+    });
+    it('should use hooks when enabled', function() {
+      var result = processProperties({Autofocus: true}, {useHooks: true});
+      expect(result.attributes.Autofocus).to.deep.equal(new Autofocus());
+    });
+    it('should transform attribute names to property names when appropriate', function() {
+      var result = processProperties({class: 'js-test'});
+      expect(result.className).to.equal('js-test');
+      expect(result.class).to.equal(undefined);
+    });
+    it('should parse style tags into CSS rules', function() {
+      var resultFromString = processProperties({style: 'color: orange; text-align: center;'});
+      expect(resultFromString.style).to.deep.equal({cssText: 'color: orange; text-align: center;'});
+      var resultFromObj = processProperties({style: {color: 'orange', 'text-align': 'center'}});
+      expect(resultFromObj.style).to.deep.equal({color: 'orange', 'text-align': 'center'});
+    });
+  });
+});

--- a/test/src/template/ractive_adaptor_spec.js
+++ b/test/src/template/ractive_adaptor_spec.js
@@ -39,9 +39,7 @@ describe('ractive_adaptor.js public API', function() {
       expect(fakeWidgetConstructor.calls.count()).to.equal(1);
       fakeWidgetConstructor.calls.reset();
     });
-
   });
-
   describe('wrap', function() {
     var wrap = ractiveAdaptor.wrap;
     it('should be a function', function() {

--- a/test/src/template/ractive_adaptor_spec.js
+++ b/test/src/template/ractive_adaptor_spec.js
@@ -25,24 +25,6 @@ describe('ractive_adaptor.js public API', function() {
     it('should be a function', function() {
       expect(attach).to.be.a('function');
     });
-    /*it('should attempt to attach widgets', function() {
-      var template = getTemplate('<div>{{value}}</div>');
-      template.templateObj.root = false;
-      var template2 = getTemplate('<div><span class="js-testChildView1">{{value}}</span></div>');
-      template2.view = {
-        el: { nodeName: 'div' },
-        childViews: {
-          'js-testChildView1': function() {},
-          'js-testChildView2': function() {}
-        }
-      };
-      var fakeWidgetConstructor = function() {
-        return {};
-      };
-      var attached = attach(template.templateObj, template2.view, fakeWidgetConstructor, {});
-      expect(attached.view).to.not.equal(undefined);
-    });*/
-
   });
 
   describe('wrap', function() {

--- a/test/src/template/ractive_adaptor_spec.js
+++ b/test/src/template/ractive_adaptor_spec.js
@@ -25,6 +25,21 @@ describe('ractive_adaptor.js public API', function() {
     it('should be a function', function() {
       expect(attach).to.be.a('function');
     });
+    it('should attempt to attach widgets', function() {
+      var template = getTemplate('<div class="js-test {{foo}}">{{value}}</div><div class="js-not-test">{{value}}</div>');
+      var template2 = getTemplate('<div><span class="js-testChildView1">{{value}}</span></div>');
+      template2.view = {
+        el: { nodeName: 'div' },
+        childViews: {
+          'js-test': function() {}
+        }
+      };
+      var fakeWidgetConstructor = jasmine.createSpy('fakeWidgetConstructor').and.returnValue({});
+      attach(template.templateObj, template2.view, fakeWidgetConstructor, {});
+      expect(fakeWidgetConstructor.calls.count()).to.equal(1);
+      fakeWidgetConstructor.calls.reset();
+    });
+
   });
 
   describe('wrap', function() {

--- a/test/src/template/ractive_adaptor_spec.js
+++ b/test/src/template/ractive_adaptor_spec.js
@@ -1,0 +1,78 @@
+'use strict';
+
+var ractiveAdaptor = require('../../../src/template/ractive_adaptor');
+var ractiveTypes = require('../../../src/template/ractive_types');
+
+var compiler = require('../../../precompile/tungsten_template/inline');
+function getTemplate(templateStr, partials) {
+  return compiler(templateStr || '', partials || {});
+}
+
+
+describe('ractive_adaptor.js public API', function() {
+  describe('render', function() {
+    var render = ractiveAdaptor.render;
+    it('should be a function', function() {
+      expect(render).to.be.a('function');
+    });
+    it('should not render undefined templates', function() {
+      expect(render({})).to.equal(undefined);
+    });
+  });
+
+  describe('attach', function() {
+    var attach = ractiveAdaptor.attach;
+    it('should be a function', function() {
+      expect(attach).to.be.a('function');
+    });
+    /*it('should attempt to attach widgets', function() {
+      var template = getTemplate('<div>{{value}}</div>');
+      template.templateObj.root = false;
+      var template2 = getTemplate('<div><span class="js-testChildView1">{{value}}</span></div>');
+      template2.view = {
+        el: { nodeName: 'div' },
+        childViews: {
+          'js-testChildView1': function() {},
+          'js-testChildView2': function() {}
+        }
+      };
+      var fakeWidgetConstructor = function() {
+        return {};
+      };
+      var attached = attach(template.templateObj, template2.view, fakeWidgetConstructor, {});
+      expect(attached.view).to.not.equal(undefined);
+    });*/
+
+  });
+
+  describe('wrap', function() {
+    var wrap = ractiveAdaptor.wrap;
+    it('should be a function', function() {
+      expect(wrap).to.be.a('function');
+    });
+    it('should wrap an element', function() {
+      var template = getTemplate('<div>{{value}}</div>');
+      var wrappedObj = wrap(template.templateObj);
+      expect(wrappedObj.t).to.equal(ractiveTypes.ELEMENT);
+      expect(wrappedObj.wrapped).to.equal(true);
+      expect(wrappedObj.f).to.deep.equal(template.templateObj);
+    });
+    it('should wrap in a div by default', function() {
+      var template = getTemplate('<div>{{value}}</div>');
+      var wrappedObj = wrap(template.templateObj);
+      expect(wrappedObj.e).to.equal('div');
+    });
+    it('should wrap a template in a chosen tag', function() {
+      var TEST_TAG = 'p';
+      var template = getTemplate('<div>{{value}}</div>');
+      var wrappedObj = wrap(template.templateObj, TEST_TAG);
+      expect(wrappedObj.e).to.equal(TEST_TAG);
+    });
+    it('should wrap the top-level element from a previous wrapping', function() {
+      var template = getTemplate('<div>{{value}}</div>');
+      var wrappedObj = wrap(template.templateObj);
+      var wrappedObj2 = wrap(wrappedObj);
+      expect(wrappedObj2.f).to.deep.equal(template.templateObj);
+    });
+  });
+});

--- a/test/src/template/template_context_spec.js
+++ b/test/src/template/template_context_spec.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var logger = require('../../../src/utils/logger');
+var Context = require('../../../src/template/template_context');
+
+describe('template_context.js public API', function() {
+  describe('lookup', function() {
+    var testContext = new Context();
+    it('should be a function', function() {
+      expect(testContext.lookup).to.be.a('function');
+    });
+    it('should return null when receiving a comment block', function() {
+      expect(testContext.lookup('!text')).to.equal(null);
+    });
+    /* develblock:start */
+    it('should be able to log using debug helpers', function() {
+      spyOn(logger, 'log');
+      testContext.lookup('!w/context');
+      testContext.lookup('!w/context/debugstring');
+      testContext.lookup('!w/lastModel/debugstring');
+      testContext.lookup('!w/debug/debugstring');
+      expect(logger.log.calls.count()).to.equal(4);
+    });
+    /* develblock:end */
+  });
+});

--- a/test/src/template/template_spec.js
+++ b/test/src/template/template_spec.js
@@ -173,3 +173,26 @@ describe('textarea value sets', function() {
     expect(output).to.equal('<textarea>' + TEST_VALUE + '</textarea>');
   });
 });
+
+describe('wrap', function() {
+  it('should be able to access the ractive adaptor\'s wrap function', function() {
+    var template = getTemplate('<div>{{value}}</div>');
+    var divWrappedTemplate = template.wrap();
+    var pWrappedTemplate = template.wrap('p');
+    expect(divWrappedTemplate.templateObj.e).to.equal('div');
+    expect(pWrappedTemplate.templateObj.e).to.equal('p');
+  });
+});
+
+describe('attachView', function() {
+  var template = getTemplate('<div>{{value}}</div>');
+  var template2 = getTemplate('<div>{{value}}</div>');
+  template2.view = {el: {nodeName: 'div'}};
+  var fakeWidgetConstructor = function() {
+    return {};
+  };
+  it('should be able to access the ractive adaptor\'s attachView function', function() {
+    var output = template.attachView(template2.view, fakeWidgetConstructor);
+    expect(output.view).to.deep.equal(template2.view);
+  });
+});

--- a/test/src/template/template_spec.js
+++ b/test/src/template/template_spec.js
@@ -173,7 +173,6 @@ describe('textarea value sets', function() {
     expect(output).to.equal('<textarea>' + TEST_VALUE + '</textarea>');
   });
 });
-
 describe('wrap', function() {
   it('should be able to access the ractive adaptor\'s wrap function', function() {
     var template = getTemplate('<div>{{value}}</div>');
@@ -183,7 +182,6 @@ describe('wrap', function() {
     expect(pWrappedTemplate.templateObj.e).to.equal('p');
   });
 });
-
 describe('attachView', function() {
   var template = getTemplate('<div>{{value}}</div>');
   var template2 = getTemplate('<div>{{value}}</div>');


### PR DESCRIPTION
Added unit tests for the template abstraction changes (listed at https://github.com/wayfair/tungstenjs/pull/106/files).

This brings coverage to 80% or more for ractive_adaptor.js, process_properties.js, html_helpers.js, and template_context.js, along with further improvements to the coverage of template.js.

Overall improvement is from 80.74% coverage to 83.5%.