### PR TITLE
Making non-source loaders optional

### DIFF
--- a/examples/base_webpack.config.js
+++ b/examples/base_webpack.config.js
@@ -3,7 +3,7 @@ var webpackSettings = require('../webpack-helper');
 
 module.exports = function (root) {
   'use strict';
-  return webpackSettings.withBabel({
+  return webpackSettings.compileSource({
     entry: './js/app',
     output: {
       filename: './js/app.min.js',

--- a/examples/base_webpack.config.js
+++ b/examples/base_webpack.config.js
@@ -3,7 +3,7 @@ var webpackSettings = require('../webpack-helper');
 
 module.exports = function (root) {
   'use strict';
-  return webpackSettings({
+  return webpackSettings.withBabel({
     entry: './js/app',
     output: {
       filename: './js/app.min.js',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",

--- a/test/build.js
+++ b/test/build.js
@@ -25,7 +25,7 @@ function getLoader(extension) {
   }
 }
 
-var debugConfig = webpackHelper({
+var debugConfig = webpackHelper.compileSource({
   entry: path.join(__dirname, '/test_target'),
   output: {
     filename: path.join(__dirname, '/testbuild.debug.js'),
@@ -46,7 +46,7 @@ var debugConfig = webpackHelper({
   }
 }, true, true);
 
-var prodConfig = webpackHelper({
+var prodConfig = webpackHelper.compileSource({
   entry: path.join(__dirname, '/test_target'),
   output: {
     filename: path.join(__dirname, '/testbuild.prod.js'),

--- a/webpack-helper.js
+++ b/webpack-helper.js
@@ -73,6 +73,17 @@ module.exports = function(config, dev, test) {
   config.module.loaders = config.module.loaders || [];
   config.module.preLoaders = config.module.preLoaders || [];
 
+  if (!dev) {
+    ensureLoader(config.module.preLoaders, /\.js$/, 'webpack-strip-block');
+  }
+  ensureLoader(config.module.loaders, /\.json$/, 'json-loader');
+  ensureLoader(config.module.loaders, /\.mustache$/, 'tungsten_template');
+
+  return config;
+};
+
+module.exports.withBabel = function(config, dev, test) {
+  config = module.exports(config, dev, test);
   // Babel should be run on our code, but not node_modules
   var folders = ['adaptors', 'examples', 'precompile', 'src', 'test'];
   folders = folders.map(function(folder) {
@@ -80,13 +91,6 @@ module.exports = function(config, dev, test) {
     return fullpath + '.*\.js';
   });
   var babelRegexStr = '^(' + folders.join('|') + ')$';
-
-  if (!dev) {
-    ensureLoader(config.module.preLoaders, /\.js$/, 'webpack-strip-block');
-  }
-  ensureLoader(config.module.loaders, /\.json$/, 'json-loader');
   ensureLoader(config.module.loaders, new RegExp(babelRegexStr), 'babel');
-  ensureLoader(config.module.loaders, /\.mustache$/, 'tungsten_template');
-
   return config;
 };

--- a/webpack-helper.js
+++ b/webpack-helper.js
@@ -47,7 +47,28 @@ function processArgs() {
  *
  * @return {Object}         Updated webpack config object
  */
-module.exports = function(config, dev, test) {
+module.exports = function(config) {
+  config.resolveLoader = config.resolveLoader || {};
+  config.resolveLoader.modulesDirectories = config.resolveLoader.modulesDirectories || [];
+
+  config.resolveLoader.modulesDirectories.push(path.join(__dirname, 'precompile'));
+
+  config.module = config.module || {};
+  config.module.loaders = config.module.loaders || [];
+  config.module.preLoaders = config.module.preLoaders || [];
+
+  ensureLoader(config.module.loaders, /\.json$/, 'json-loader');
+  ensureLoader(config.module.loaders, /\.mustache$/, 'tungsten_template');
+
+  return config;
+};
+
+module.exports.compileSource = function(config, dev, test) {
+  config = module.exports(config, dev, test);
+
+  config.resolveLoader = config.resolveLoader || {};
+  config.resolveLoader.modulesDirectories.push(path.join(__dirname, 'node_modules'));
+
   var args = processArgs();
   // If dev is not explicitly set to a boolean, check for the command line flag
   if (dev !== Boolean(dev)) {
@@ -63,27 +84,6 @@ module.exports = function(config, dev, test) {
     TUNGSTENJS_IS_TEST: test
   }));
 
-  config.resolveLoader = config.resolveLoader || {};
-  config.resolveLoader.modulesDirectories = config.resolveLoader.modulesDirectories || [];
-
-  config.resolveLoader.modulesDirectories.push(path.join(__dirname, 'precompile'));
-  config.resolveLoader.modulesDirectories.push(path.join(__dirname, 'node_modules'));
-
-  config.module = config.module || {};
-  config.module.loaders = config.module.loaders || [];
-  config.module.preLoaders = config.module.preLoaders || [];
-
-  if (!dev) {
-    ensureLoader(config.module.preLoaders, /\.js$/, 'webpack-strip-block');
-  }
-  ensureLoader(config.module.loaders, /\.json$/, 'json-loader');
-  ensureLoader(config.module.loaders, /\.mustache$/, 'tungsten_template');
-
-  return config;
-};
-
-module.exports.withBabel = function(config, dev, test) {
-  config = module.exports(config, dev, test);
   // Babel should be run on our code, but not node_modules
   var folders = ['adaptors', 'examples', 'precompile', 'src', 'test'];
   folders = folders.map(function(folder) {
@@ -92,5 +92,10 @@ module.exports.withBabel = function(config, dev, test) {
   });
   var babelRegexStr = '^(' + folders.join('|') + ')$';
   ensureLoader(config.module.loaders, new RegExp(babelRegexStr), 'babel');
+
+  if (!dev) {
+    ensureLoader(config.module.preLoaders, /\.js$/, 'webpack-strip-block');
+  }
+
   return config;
 };

--- a/webpack.standalone.js
+++ b/webpack.standalone.js
@@ -1,8 +1,7 @@
-var path = require('path');
 var webpack = require('webpack');
 var webpackSettings = require('./webpack-helper');
 
-module.exports = webpackSettings({
+module.exports = webpackSettings.withBabel({
   entry: {
     'backbone': './adaptors/backbone',
     'ampersand': './adaptors/ampersand',

--- a/webpack.standalone.js
+++ b/webpack.standalone.js
@@ -1,7 +1,7 @@
 var webpack = require('webpack');
 var webpackSettings = require('./webpack-helper');
 
-module.exports = webpackSettings.withBabel({
+module.exports = webpackSettings.compileSource({
   entry: {
     'backbone': './adaptors/backbone',
     'ampersand': './adaptors/ampersand',


### PR DESCRIPTION
Projects using the /dist build will still need to use webpack-helper to get template compilation.
Moving all unneeded loaders to a separate function to minimize webpack build time