### PR TITLE
Resolves several of the reported DOM/VDOM differences

### DIFF
--- a/src/debug/vtree_to_string.js
+++ b/src/debug/vtree_to_string.js
@@ -24,8 +24,11 @@ function toString(vtree, escaped) {
       if (virtualDomImplementation.isHook(val)) {
         return;
       }
-      if (key === 'attributes') {
+      if (key === 'attributes' || key === 'namespace') {
         return;
+      }
+      if (key.toLowerCase() === 'style') {
+        val = val.cssText;
       }
       if (key.toLowerCase() === 'contenteditable' && val.toLowerCase() === 'inherit') {
         return;


### PR DESCRIPTION
The Debugger will often report DOM differences if a style attribute or svg element was used due to how it's processed. This resolves many of those cases though style attributes will need to be revisited for reasons testable on the svg example ("83.33333333333px" is truncated to "83.3333px")