### PR TITLE
Added decoding to the string parser for entities within attribute values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",

--- a/src/template/stacks/string.js
+++ b/src/template/stacks/string.js
@@ -1,12 +1,26 @@
 'use strict';
 
 var DefaultStack = require('./default');
+var htmlParser = require('../html_parser');
 
 function StringStack(attributesOnly, debugMode) {
   DefaultStack.call(this, attributesOnly, debugMode);
 }
 StringStack.prototype = new DefaultStack();
 StringStack.prototype.constructor = StringStack;
+
+StringStack.prototype.createObject = function(obj, options) {
+  if (typeof obj === 'string' && options && options.parse) {
+    // Naive check to avoid parsing if value contains nothing HTML-ish or HTML-entity-ish
+    if (obj.indexOf('<') > -1 || obj.indexOf('&') > -1) {
+      htmlParser(obj, this);
+    } else {
+      this._closeElem(obj);
+    }
+  } else {
+    this._closeElem(obj);
+  }
+};
 
 StringStack.prototype.openElement = function() {
   throw 'An attribute cannot contain an element';


### PR DESCRIPTION
Unicode entities within attribute values were being left unencoded displaying as `&eacute;` instead of `é` for example. This reuses the parsing from the VDom stack in the String stack to ensure entities are properly encoded

[update to show encoding issue - AR]