### PR TITLE
Smaller polyfill for jQuery

### DIFF
--- a/examples/base_webpack.config.js
+++ b/examples/base_webpack.config.js
@@ -13,7 +13,7 @@ module.exports = function (root) {
       alias: {
         // Tungsten.js doesn't need jQuery, but backbone needs a subset of jQuery APIs.  Backbone.native
         // implements tha minimum subset of required functionality
-        'jquery': 'backbone.native',
+        'jquery': path.join(__dirname, '../src/polyfill/jquery'),
         //  Aliases for the current version of tungstenjs above the ./examples directory.  If
         //  examples dir is run outside of main tungstenjs repo, remove these aliases
         //  and use via normal modules directories (e.g., via NPM)

--- a/examples/dbmonster/js/app.js
+++ b/examples/dbmonster/js/app.js
@@ -29,7 +29,7 @@ var TableView = BaseView.extend({
   debugName: 'tableView'
 });
 window.table = new TableView({
-  el: '#appwrapper',
+  el: document.getElementById('appwrapper'),
   template: template,
   model: new TableModel({}),
   dynamicInitialize: true

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-plugin-transform-es2015-parameters": "^6.3.13",
     "babel-plugin-transform-es2015-shorthand-properties": "^6.3.13",
     "backbone": "^1.1.2",
-    "backbone.native": "~1.0.0",
+    "backbone.nativeajax": "^0.4.3",
     "data-set": "^4.0.0",
     "form-serialize": "^0.6.0",
     "htmlparser2": "^3.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ In Tungsten.js, the initial page loaded is rendered with [Mustache](http://musta
 
 An adaptor layer is used to connect with Tungsten.js with a preferred modular client-side framework to handle data and view management.  The default adaptor is a thin layer on top of [Backbone.js](https://github.com/jashkenas/backbone) with a `childViews` hash to define relationships between views and a `compiledTemplate` property to define the root pre-compiled template function.  There is also a similar Ampersand.js adaptor available.  The preferred adaptor can be included via CommonJS or ES6 Modules at `tungstenjs/adaptors/backbone/index.js` or `tungstenjs/adaptors/ampersand/index.js` and exposes base modules for Backbone or Ampersand (as well as a direct reference to Backbone or Ampersand itself).
 
-Tungsten.js has no hard dependency on [jQuery](https://github.com/jquery/jquery), and the default build uses the jQuery-less [backbone.native](https://github.com/inkling/backbone.native) in its Backbone adaptor.  For IE8 support, jQuery 1.x should be used instead.
+Tungsten.js has no dependency on [jQuery](https://github.com/jquery/jquery).
 
 ## Setup
 
@@ -40,7 +40,7 @@ For the latest, but unstable, version:
 
 ### UMD
 
-The UMD build is also available for including Tungsten.js in a project.  It assumes [underscore](http://underscorejs.org/) is included as `window._`.  Other dependencies are bundled in the build, including [backbone.native](https://github.com/inkling/backbone.native) as a shim for jQuery.
+The UMD build is also available for including Tungsten.js in a project.  It assumes [underscore](http://underscorejs.org/) is included as `window._`.  Other dependencies are bundled in the build.
 
 ```html
 <!-- Include underscore -->
@@ -65,14 +65,14 @@ An client-side only example of a Tungsten.js app using the UMD build is availabl
 
 ### Bundler (e.g., webpack)
 
-The recommended method of adding Tungsten.js to your application is via a module bundler such as [webpack](http://webpack.github.io/).  Tungsten.js with the Backbone or Ampersand adaptor expects `jquery` to be shimmed, either with jQuery itself (jQuery 1.x is required for IE8 support) or with the jQuery-less shim [backbone.native](https://github.com/inkling/backbone.native).  With webpack, this looks like:
+The recommended method of adding Tungsten.js to your application is via a module bundler such as [webpack](http://webpack.github.io/).  Because Backbone expects `jQuery` to be present, Tungsten.js includes a jQuery-less shim, `src/polyfill/jquery`, which is included in the webpack build:
 
 ```javascript
 module.exports = {
   // [...]
   resolve: {
     alias: {
-      'jquery': 'backbone.native'
+      'jquery': path.join(__dirname, '../src/polyfill/jquery')
     }
   }
 };

--- a/src/polyfill/jquery.js
+++ b/src/polyfill/jquery.js
@@ -24,7 +24,19 @@ function $(element) {
 }
 
 $.prototype = {
-  attr: _.noop
+  attr: function(attrs) {
+    _.each(attrs, function(value, attr) {
+      switch (attr) {
+        case 'class':
+          this[0].className = value;
+          break;
+        default:
+          this[0].setAttribute(attr, value);
+          break;
+      }
+    }, this);
+    return this;
+  }
 };
 
 $.ajax = require('backbone.nativeajax');

--- a/src/polyfill/jquery.js
+++ b/src/polyfill/jquery.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var _ = require('underscore');
+
+/**
+ * Construct a new jQuery-style element representation.
+ *
+ * @param {Element} element An existing element to wrap.
+ */
+function $(element) {
+  // Call as a constructor if it was used as a function.
+  if (!(this instanceof $)) {
+    return new $(element);
+  }
+
+  if (!element) {
+    this.length = 0;
+  } else {
+    // This handles both the 'Element' and 'Window' case, as both support
+    // event binding via 'addEventListener'.
+    this[0] = element;
+    this.length = 1;
+  }
+}
+
+$.prototype = {
+  attr: _.noop
+};
+
+$.ajax = require('backbone.nativeajax');
+
+module.exports = $;

--- a/test/build.js
+++ b/test/build.js
@@ -41,7 +41,7 @@ var debugConfig = webpackHelper.compileSource({
   },
   resolve: {
     alias: {
-      'jquery': 'backbone.native'
+      'jquery': path.join(__dirname, '../src/polyfill/jquery')
     }
   }
 }, true, true);
@@ -62,7 +62,7 @@ var prodConfig = webpackHelper.compileSource({
   },
   resolve: {
     alias: {
-      'jquery': 'backbone.native'
+      'jquery': path.join(__dirname, '../src/polyfill/jquery')
     }
   }
 }, false, true);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
   },
   resolve: {
     alias: {
-      'jquery': 'backbone.native'
+      'jquery': path.join(__dirname, './src/polyfill/jquery')
     }
   },
   devtool: '#source-map',

--- a/webpack.standalone.js
+++ b/webpack.standalone.js
@@ -1,5 +1,6 @@
 var webpack = require('webpack');
 var webpackSettings = require('./webpack-helper');
+var path = require('path');
 
 module.exports = webpackSettings.compileSource({
   entry: {

--- a/webpack.standalone.js
+++ b/webpack.standalone.js
@@ -15,7 +15,7 @@ module.exports = webpackSettings.compileSource({
   },
   resolve: {
     alias: {
-      jquery: 'backbone.native'
+      jquery: path.join(__dirname, './src/polyfill/jquery')
     }
   },
   externals: [


### PR DESCRIPTION
Most of what was in backbone.native was unnecessary since Tungsten overrides most of the functions that use it. This reduces the code to a constructor with a no-op 'attr' function and static ajax function, provided by a more targetted module backbone.nativeajax.