### PR TITLE
add check to ignore 'set' attributes equal to null

### DIFF
--- a/adaptors/backbone/base_model.js
+++ b/adaptors/backbone/base_model.js
@@ -444,6 +444,9 @@ BaseModel.prototype.set = function(key, val, options) {
   for (attr in attrs) {
     if (attrs.hasOwnProperty(attr)) {
       val = attrs[attr];
+      if (val === null) {
+        continue;
+      }
 
       // Inject in the relational lookup
       var opts = options;


### PR DESCRIPTION
This prevents DOM does not match VDOM errors in instances where an attribute on the server is null. (In those instances, the attribute still gets serialized to the model, but is considered absent for purposes of templated construction of the initial DOM, hence the diffing error).