### PR TITLE
Clearing html parser between html strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",

--- a/src/template/html_parser.js
+++ b/src/template/html_parser.js
@@ -29,7 +29,9 @@ module.exports = function(html, stack) {
     _stack = defaultStack;
   }
 
+  parser.reset();
   parser.end(html);
+  // @TODO add logging when parser._stack.length > 0 as the html string left behind tags
 
   if (!stack) {
     return _stack.getOutput();


### PR DESCRIPTION
Invalid HTML would cause parser._stack to have tags left on in until the next cycle where the were oddly injected causing errors. This resets the parser's data before each run to ensure a clean pass.