### PR TITLE
Unprocessed lambdas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",

--- a/src/template/adaptor.js
+++ b/src/template/adaptor.js
@@ -164,11 +164,14 @@ function render(stack, template, context, partials, parentView) {
             if (lambdaValue) {
               if (typeof lambdaValue === 'string') {
                 var resultHasClass = lambdaValue.indexOf(' class="') > -1 && parentView.childViews;
-                var resultHasMustache = lambdaValue.indexOf('{{');
+                var resultHasMustache = lambdaValue.indexOf('{{') > -1;
                 if (resultHasMustache || resultHasClass) {
                   var lambdaTemplateData = compiler(lambdaValue);
                   if (resultHasClass) {
-                    lambdaTemplateData.template = lambdaTemplateData.template.attachView(parentView);
+                    lambdaTemplateData.template = lambdaTemplateData.template.attachView({
+                      el: false,
+                      childViews: parentView.childViews
+                    });
                   }
                   lambdaValue = lambdaTemplateData.template.templateObj;
                 } else {


### PR DESCRIPTION
Since some lambdas contain contents that aren't exactly valid HTML, but are processed into valid things.
This adds a flag for the compiler to leave the contents of given lambdas unprocessed so that they are in pure string form when processed.