### PR TITLE
Adding childView validation to prevent invalid declarations

### DIFF
--- a/adaptors/ampersand/base_view.js
+++ b/adaptors/ampersand/base_view.js
@@ -12,6 +12,7 @@ var logger = require('../../src/utils/logger');
 
 // Cached regex to split keys for `delegate`.
 var delegateEventSplitter = /^(\S+)\s*(.*)$/;
+var validate = require('../shared/validate');
 
 /**
  * Provides generic reusable methods that child views can inherit from
@@ -529,6 +530,10 @@ BaseView.extend = function(protoProps) {
     }
   }
   /* develblock:end */
+
+  if (protoProps && protoProps.childViews) {
+    validate.childViews(protoProps.childViews);
+  }
 
   return AmpersandView.extend.call(this, protoProps);
 };

--- a/adaptors/backbone/base_view.js
+++ b/adaptors/backbone/base_view.js
@@ -12,6 +12,7 @@ var ViewWidget = require('./backbone_view_widget');
 var ComponentWidget = require('./component_widget');
 
 var renderQueue = require('../shared/render_queue');
+var validate = require('../shared/validate');
 
 // Cached regex to split keys for `delegate`.
 var delegateEventSplitter = /^(\S+)\s*(.*)$/;
@@ -578,6 +579,10 @@ var BaseView = Backbone.View.extend({
       }
     }
     /* develblock:end */
+
+    if (protoProps && protoProps.childViews) {
+      validate.childViews(protoProps.childViews);
+    }
 
     return Backbone.View.extend.call(this, protoProps, staticProps);
   }

--- a/adaptors/shared/validate.js
+++ b/adaptors/shared/validate.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports.childViews = function(childViews) {
+  for (var selector in childViews) {
+    if (selector.substr(0, 4) === '.js-') {
+      throw new Error('Child views cannot start with a period: "' + selector + '"');
+    } else if (selector.substr(0, 3) !== 'js-') {
+      throw new Error('Child views must start with "js-": "' + selector + '"');
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",

--- a/test/adaptors/ampersand/base_view_spec.js
+++ b/test/adaptors/ampersand/base_view_spec.js
@@ -18,6 +18,15 @@ describe('base_view.js public api', function() {
     it('should be different than Ampersand\'s', function() {
       expect(BaseView.extend).not.to.equal(Ampersand.View.extend);
     });
+    it('should validate the childView array', function() {
+      var validate = require('../../../adaptors/shared/validate');
+      spyOn(validate, 'childViews');
+      var data = {
+        childViews: {}
+      };
+      BaseView.extend(data);
+      jasmineExpect(validate.childViews).toHaveBeenCalledWith(data.childViews);
+    });
     /* develblock:start */
     it('should prevent initialize from being overwritten', function() {
       spyOn(logger, 'warn');

--- a/test/adaptors/backbone/base_view_spec.js
+++ b/test/adaptors/backbone/base_view_spec.js
@@ -18,6 +18,15 @@ describe('base_view.js public api', function() {
     it('should be different than Backbone\'s', function() {
       expect(BaseView.extend).not.to.equal(Backbone.extend);
     });
+    it('should validate the childView array', function() {
+      var validate = require('../../../adaptors/shared/validate');
+      spyOn(validate, 'childViews');
+      var data = {
+        childViews: {}
+      };
+      BaseView.extend(data);
+      jasmineExpect(validate.childViews).toHaveBeenCalledWith(data.childViews);
+    });
     /* develblock:start */
     it('should prevent initialize from being overwritten', function() {
       spyOn(logger, 'warn');

--- a/test/adaptors/shared/validate_spec.js
+++ b/test/adaptors/shared/validate_spec.js
@@ -1,0 +1,26 @@
+var validate = require('../../../adaptors/shared/validate');
+
+describe('validate', function() {
+  describe('childViews', function() {
+    it('should be a function', function() {
+      expect(validate.childViews).to.be.a('function');
+      expect(validate.childViews).to.have.length(1);
+    });
+    it('should throw for invalid childViews', function() {
+      var fn1 = function() {
+        validate.childViews({'.js-child': null});
+      };
+      var fn2 = function() {
+        validate.childViews({'child': null});
+      };
+      expect(fn1).to.throw();
+      expect(fn2).to.throw();
+    });
+    it('should not throw for valid childViews', function() {
+      var fn = function() {
+        validate.childViews({'js-child': null});
+      };
+      expect(fn).not.to.throw();
+    });
+  });
+});


### PR DESCRIPTION
Added new exception to prevent invalid childViews. Explicitly called out the common error case of a preceeding period on an otherwise valid property.