### PR TITLE
Fix Published UMD

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,7 @@
   },
   "env": {
     "es6": true,
-    "browser": true
+    "shared-node-browser": true
   },
   "globals": {
     "require": true,

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ examples/**/*.js.map
 examples/**/*.min.js
 .DS_Store
 output/
+npm-debug.log

--- a/adaptors/ampersand/index.js
+++ b/adaptors/ampersand/index.js
@@ -27,6 +27,7 @@ module.exports = {
     Model: require('ampersand-model'),
     View: require('ampersand-view')
   },
+  _: require('underscore'),
   Template: require('../../src/template/template.js'),
   addEventPlugin: tungsten.addEventPlugin,
   _core: tungsten,

--- a/adaptors/backbone/index.js
+++ b/adaptors/backbone/index.js
@@ -24,6 +24,7 @@ module.exports = {
   View: require('./base_view'),
   ViewWidget: require('./backbone_view_widget'),
   Backbone: require('backbone'),
+  _: require('underscore'),
   ComponentWidget: require('./component_widget'),
   Template: require('../../src/template/template.js'),
   addEventPlugin: tungsten.addEventPlugin,

--- a/adaptors/shared/animation_frame.js
+++ b/adaptors/shared/animation_frame.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var window = require('global/window');
 var _ = require('underscore');
 var animFrame = {
   request: null,

--- a/examples/dbmonster/js/app.js
+++ b/examples/dbmonster/js/app.js
@@ -1,11 +1,13 @@
 'use strict';
 
-var TungstenBackboneBase = require('tungstenjs/adaptors/backbone');
-var BaseView = TungstenBackboneBase.View;
-var BaseModel = TungstenBackboneBase.Model;
-var BaseCollection = TungstenBackboneBase.Collection;
+var tungsten = require('tungstenjs');
+var BaseView = tungsten.View;
+var BaseModel = tungsten.Model;
+var BaseCollection = tungsten.Collection;
 var template = require('../templates/table.mustache');
+
 require('./database-generator');
+
 var TableModel = BaseModel.extend({
   defaults: {
     dbs: []

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/wayfair/tungstenjs.git"
   },
   "bugs": "https://github.com/wayfair/tungstenjs/issues",
-  "main": "tungsten.js",
+  "main": "./dist/tungsten.backbone.js",
   "scripts": {
     "clean": "rm dist/*.js",
     "jasmine": "node test/jasmine.js",
@@ -38,6 +38,7 @@
     "entities": "^1.1.1",
     "extend": "^3.0.0",
     "form-serialize": "^0.6.0",
+    "global": "^4.3.0",
     "htmlparser2": "^3.8.3",
     "jsdom": "^6.5.0",
     "json-loader": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",

--- a/precompile/tungsten_template/index.js
+++ b/precompile/tungsten_template/index.js
@@ -25,7 +25,7 @@ module.exports = function(contents) {
   var templatePath = path.relative(path.dirname(module.dest), __dirname + '/template');
   templatePath = templatePath.replace(/\\/g, '/');
 
-  var output = 'var Template=require("tungstenjs/src/template/template");';
+  var output = 'var Template=require("tungstenjs").Template;';
   output += 'var template=new Template(' + JSON.stringify(templateData.templateObj) + ');';
   output += 'module.exports=template;';
   var partials = templateData.tokens.partials;

--- a/readme.md
+++ b/readme.md
@@ -42,18 +42,20 @@ For the latest, but unstable, version:
 
 ### UMD
 
-The UMD build is also available for including Tungsten.js in a project.  It assumes [underscore](http://underscorejs.org/) is included as `window._`.  Other dependencies are bundled in the build.
+The UMD build is also available for including Tungsten.js in a project.
+Dependencies are bundled in the build.  It exposes [underscore] and [backbone]
+as `tungstenjs._` and `tungstenjs.Backbone` respectively.
 
-```html
-<!-- Include underscore -->
-<script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
-<!-- Backbone.js Adaptor -->
-<script src="./node_modules/tungstenjs/dist/tungsten.backbone.js"></script>
-```
+To compile templates, use
+`tungsten._template.compileTemplates({myTemplate: 'Hello {{name}.'})`.
+Ordinarily this is done on the server at build time.
 
-To compile templates, use `tungsten._template.compileTemplates({myTemplate: 'Hello {{name}.'})`.  Ordinarily this is done on the server at build time.
+An client-side only example of a Tungsten.js app using the UMD build is
+available in the [examples].
 
-An client-side only example of a Tungsten.js app using the UMD build is available in the [examples](https://github.com/wayfair/tungstenjs/tree/master/examples/browser-standalone).
+[underscore]: http://underscorejs.org/
+[backbone]: http://backbonejs.org/
+[examples]: https://github.com/wayfair/tungstenjs/tree/master/examples/browser-standalone
 
 ### Bundler (e.g., webpack)
 

--- a/src/debug/highlighter.js
+++ b/src/debug/highlighter.js
@@ -4,6 +4,8 @@
  * Chrome DevTools-esque plugin to highlight DOM elements from debugger panel
  */
 
+var document = require('global/document');
+var window = require('global/window');
 var utils = require('./panel_js/utils');
 
 var isNode = require('./is_node');

--- a/src/debug/panel_js/app_data.js
+++ b/src/debug/panel_js/app_data.js
@@ -1,5 +1,6 @@
 'use strict';
 /* global TUNGSTENJS_VERSION */
+var window = require('global/window');
 var isNode = require('../is_node');
 var _ = require('underscore');
 var styles = isNode ? '' : (

--- a/src/debug/panel_js/model_panel_events.js
+++ b/src/debug/panel_js/model_panel_events.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var window = require('global/window');
 var _ = require('underscore');
 var logger = require('../../utils/logger');
 var utils = require('./utils');
@@ -169,7 +170,7 @@ module.exports = function() {
     }
     var model = appData.selectedModel.obj;
     if (model.has(name)) {
-      alert('Model already has property named "' + name + '"');
+      window.alert('Model already has property named "' + name + '"');
     } else {
       model.set(name, value);
       appData.settings.modelProperties = appData.settings.modelProperties || {};

--- a/src/debug/panel_js/view_panel_events.js
+++ b/src/debug/panel_js/view_panel_events.js
@@ -1,5 +1,6 @@
 'use strict';
-
+const document = require('global/document');
+const window = require('global/window');
 const _ = require('underscore');
 const utils = require('./utils');
 const appData = require('./app_data');

--- a/src/debug/registry.js
+++ b/src/debug/registry.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var window = require('global/window');
 var _ = require('underscore');
 var eventBus = require('./event_bus');
 

--- a/src/debug/timer.js
+++ b/src/debug/timer.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var window = require('global/window');
 var _ = require('underscore');
 var process = require('process');
 var logger = require('../utils/logger');

--- a/src/debug/window_manager.js
+++ b/src/debug/window_manager.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var document = require('global/document');
+var window = require('global/window');
 var _ = require('underscore');
 var utils = require('./panel_js/utils');
 var appData = require('./panel_js/app_data');

--- a/src/event/global_events.js
+++ b/src/event/global_events.js
@@ -2,6 +2,7 @@
  * Utility class to non-directly bind events
  */
 'use strict';
+var window = require('global/window');
 var _ = require('underscore');
 var eventsCore = require('./events_core');
 

--- a/src/event/handlers/change_events.js
+++ b/src/event/handlers/change_events.js
@@ -3,6 +3,7 @@
  */
 'use strict';
 
+var document = require('global/document');
 var eventsCore = require('../events_core');
 var defaultEvents = require('./default_events');
 

--- a/src/event/handlers/default_events.js
+++ b/src/event/handlers/default_events.js
@@ -3,6 +3,7 @@
  */
 'use strict';
 
+var document = require('global/document');
 var eventsCore = require('../events_core');
 
 module.exports = function(el, eventName, selector, method) {

--- a/src/event/handlers/window_events.js
+++ b/src/event/handlers/window_events.js
@@ -3,6 +3,7 @@
  */
 'use strict';
 
+var window = require('global/window');
 var eventsCore = require('../events_core');
 var eventWrapper = require('../tungsten_event');
 

--- a/src/template/hooks/autofocus.js
+++ b/src/template/hooks/autofocus.js
@@ -7,6 +7,7 @@
 
 'use strict';
 
+var document = require('global/document');
 var featureDetect = require('../../utils/feature_detect');
 
 var isiOS = featureDetect.isiOS();

--- a/src/template/stacks/default.js
+++ b/src/template/stacks/default.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var document = require('global/document');
 var processProperties = require('../process_properties');
 var logger = require('../../utils/logger');
 

--- a/src/template/stacks/dom.js
+++ b/src/template/stacks/dom.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var document = require('global/document');
 var _ = require('underscore');
 var DefaultStack = require('./default');
 var virtualDomImplementation = require('../../vdom/virtual_dom_implementation');

--- a/src/template/widgets/html_comment.js
+++ b/src/template/widgets/html_comment.js
@@ -9,6 +9,7 @@
  */
 
 'use strict';
+var document = require('global/document');
 
 /**
  * Wrapper Widget for child views

--- a/src/tungsten.js
+++ b/src/tungsten.js
@@ -10,6 +10,7 @@
  */
 /* global TUNGSTENJS_VERSION */
 'use strict';
+var document = require('global/document');
 var globalEvents = require('./event/global_events');
 var virtualDomImplementation = require('./vdom/virtual_dom_implementation');
 var virtualHyperscript = require('./vdom/virtual_hyperscript');

--- a/src/utils/feature_detect.js
+++ b/src/utils/feature_detect.js
@@ -4,11 +4,12 @@
  * @author Andrew Rota <rota.andrew@gmail.com>
  */
 'use strict';
+var window = require('global/window');
 module.exports = {
   isiOS: function() {
-    if (!navigator) {
+    if (!window.navigator) {
       return false;
     }
-    return /iPhone|iPad|iPod/i.test(navigator.userAgent);
+    return /iPhone|iPad|iPod/i.test(window.navigator.userAgent);
   }
 };

--- a/test/src/utils/feature_detect_spec.js
+++ b/test/src/utils/feature_detect_spec.js
@@ -1,51 +1,58 @@
 'use strict';
 
+var window = require('global/window');
 var featureDetect = require('../../../src/utils/feature_detect.js');
 
 describe('feature_detect.js public API', function() {
+  beforeEach(function () {
+    this.originalNavigator = window.navigator;
+    window.navigator = {};
+  });
+
+  afterEach(function () {
+    window.navigator = this.originalNavigator;
+  });
+
   describe('isiOS', function() {
     it('should be a function', function() {
       expect(featureDetect.isiOS).to.be.a('function');
     });
 
-    var originalNavigator = global.navigator;
     it('should not fail if navigator is not present', function() {
-      global.navigator = null;
+      window.navigator = null;
       expect(featureDetect.isiOS()).to.be.false;
     });
     it('should positively identify iPads', function() {
-      global.navigator = {
+      window.navigator = {
         userAgent: 'Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10'
       };
       expect(featureDetect.isiOS()).to.be.true;
     });
     it('should positively identify iPhones', function() {
-      global.navigator = {
+      window.navigator = {
         userAgent: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_1 like Mac OS X; nb-no) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5'
       };
       expect(featureDetect.isiOS()).to.be.true;
     });
     it('should positively identify iPod', function() {
-      global.navigator = {
+      window.navigator = {
         userAgent: 'Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5'
       };
       expect(featureDetect.isiOS()).to.be.true;
     });
 
     it('should negatively identify Android', function() {
-      global.navigator = {
+      window.navigator = {
         userAgent: 'Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.65 Mobile Safari/537.36'
       };
       expect(featureDetect.isiOS()).to.be.false;
     });
 
     it('should negatively identify IE', function() {
-      global.navigator = {
+      window.navigator = {
         userAgent: 'Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; GTB7.4; InfoPath.2; SV1; .NET CLR 3.3.69573; WOW64; en-US)'
       };
       expect(featureDetect.isiOS()).to.be.false;
     });
-
-    global.navigator = originalNavigator;
   });
 });

--- a/webpack-helper.js
+++ b/webpack-helper.js
@@ -63,6 +63,7 @@ module.exports = function(config) {
   config.resolve = config.resolve || {};
   config.resolve.alias = config.resolve.alias || {};
   config.resolve.alias.entities = path.join(__dirname, './node_modules/entities');
+  config.resolve.alias.global = path.join(__dirname, './node_modules/global');
 
   return config;
 };

--- a/webpack.standalone.js
+++ b/webpack.standalone.js
@@ -43,10 +43,6 @@ module.exports = webpackSettings.compileSource({
       jquery: path.join(__dirname, './src/polyfill/jquery')
     }
   },
-  externals: [
-    {underscore: 'var window._'},
-    {lodash: 'var window._'}
-  ],
   resolveLoader: {
     modulesDirectories: ['node_modules']
   },


### PR DESCRIPTION
## Changes

- change module entry point to backbone adapter UMD
- change eslint env to `shared-node-browser`
- integrate with `global` module
- update template precompiler to reference UMD
- update `dbmonster` example app
- change `webpack-helper` to ensure global is not bundled twice (Using solution found in 6a6eacc)
- expose `underscore` in the top level tungsten api (eg: `var _ = require('tungstenjs')._;`)

## Changes to eslint

This will fail:
```js
window.alert('Alert!');
```

This will not:
```js
var window = require('global/window');
window.alert('Alert!');
```