### PR TITLE
Adds simple checks for PropTypes.

### DIFF
--- a/adaptors/backbone/base_model.js
+++ b/adaptors/backbone/base_model.js
@@ -435,6 +435,66 @@ BaseModel.prototype.bindExposedEvent = function(event, prop, childComponent) {
   });
 };
 
+BaseModel.prototype.validateProperty = function (propTypeDesc, propValue) {
+  var validDescAttrs = ['required', 'type'];
+  var propValueType = typeof propValue;
+  var isRequired = propTypeDesc.required;
+  var type = propTypeDesc.type;
+  var typeValidators = {
+    string: (value) => typeof value === 'string',
+    number: (value) => typeof value === 'number',
+    boolean: (value) => typeof value === 'boolean',
+    object: (value) => typeof value === 'object',
+    custom: (value) => typeof value === 'function',
+    symbol: (value) => typeof value === 'symbol',
+    array: (value) => _.isArray(value)
+  };
+
+  /**
+   * Checks if target object has at least one attribute from attrs array.
+   *
+   * @param  {Object}   target  Object to check for attributes
+   * @param  {Array}    attrs   Array of attributes
+   *
+   * @return {Boolean}
+   */
+  function hasAtLeastOneKey(target, attrs) {
+    var attrsLen = attrs.length;
+    var i = 0;
+    var counter = 0;
+    for (; i < attrsLen; i++) {
+      if (target[attrs[i]] !== undefined) {
+        counter++;
+      }
+    }
+    return !!counter;
+  }
+
+  // check if propTypeDesc is an object and has at lest one valid attribute
+  if (typeof propTypeDesc !== 'object' || !hasAtLeastOneKey(propTypeDesc, validDescAttrs)) {
+    throw({msg: 'invalid property descriptor.'});
+  }
+
+  // validate property type only when it was specified and is a string
+  if (typeof type !== 'string' || Object.keys(typeValidators).indexOf(type) === -1 ) {
+    throw({msg: 'unsupported property type of `' + JSON.stringify(type) + '`.'});
+  }
+
+  if (isRequired) {
+    if (propValue === undefined) {
+      throw({msg: 'was required, but never specified.'});
+    }
+    if (type && !typeValidators[type](propValue)) {
+      throw({msg: 'expected property type of `' + type + '`, but got `' + propValueType + '`.'});
+    }
+  } else {
+    if (propValue && type && !typeValidators[type](propValue)) {
+      throw({msg: 'expected property type of `' + type + '`, but got `' + propValueType + '`.'});
+    }
+  }
+  return true;
+};
+
 BaseModel.prototype.set = function(key, val, options) {
   var attr, attrs, unset, changes, silent, changing, prev, current;
   if (key == null) {
@@ -450,62 +510,19 @@ BaseModel.prototype.set = function(key, val, options) {
   }
 
   options = options || {};
-
-  /* develblock:start */
-
-  // PropTypes Start
-
   var propTypes = _.result(this, 'propTypes') || {};
 
-  function validatePropertyType(propTypeDesc, propValue) {
-    var validTypesHash = {
-      string: 'string',
-      number: 'number',
-      boolean: 'boolean',
-      array: 'object',
-      object: 'object',
-      custom: 'function',
-      symbol: 'symbol'
-    };
-    var propValueType = typeof propValue;
-    var isRequired = propTypeDesc.required;
-    var type = propTypeDesc.type;
-
-    // check if propTypeDesc is an object and has at lest one valid option
-    if (!_.isObject(propTypeDesc) || !_.intersection(['type', 'required'], _.keys(propTypeDesc)).length) {
-      throw({msg: 'invalid property descriptor.'});
-    }
-
-    // validate property type only when it was specified
-    if (propTypeDesc.hasOwnProperty('type') && (!_.isString(type) || _.keys(validTypesHash).indexOf(type) < 0 )) {
-      throw({msg: 'unsupported property type of `' + JSON.stringify(type) + '`.'});
-    }
-
-    if (isRequired) {
-      if (propValue === undefined) {
-        throw({msg: 'was required, but never specified.'});
-      }
-      if (type && validTypesHash[type] !== propValueType) {
-        throw({msg: 'expected property type of `' + type + '`, but got `' + propValueType + '`.'});
-      }
-    } else {
-      if (propValue && type && validTypesHash[type] !== propValueType) {
-        throw({msg: 'expected property type of `' + type + '`, but got `' + propValueType + '`.'});
-      }
-    }
-    return true;
-  }
-
+  // iterate though properties and check if valid
   _.each(propTypes, (propType, propName) => {
     var propValue = attrs[propName];
     try {
-      validatePropertyType(propType, propValue);
+      this.validateProperty(propType, propValue);
     } catch (err) {
       throw new TypeError('PropTypes.' + propName + ' ' + err.msg);
     }
   });
 
-  // PropTypes End
+  /* develblock:start */
 
   // In order to compare server vs. client data, save off the initial data
   if (!this.initialData) {
@@ -517,6 +534,7 @@ BaseModel.prototype.set = function(key, val, options) {
       logger.warn('Model expected object of attributes but got: ' + initialStr);
     }
   }
+
   /* develblock:end */
 
   // Run validation.

--- a/adaptors/backbone/base_model.js
+++ b/adaptors/backbone/base_model.js
@@ -470,13 +470,13 @@ BaseModel.prototype.validateProperty = function (propTypeDesc, propValue) {
     return !!counter;
   }
 
-  // check if propTypeDesc is an object and has at lest one valid attribute
+  // check if propTypeDesc is an object and has at least one valid attribute
   if (typeof propTypeDesc !== 'object' || !hasAtLeastOneKey(propTypeDesc, validDescAttrs)) {
     throw({msg: 'invalid property descriptor.'});
   }
 
   // validate property type only when it was specified and is a string
-  if (typeof type !== 'string' || Object.keys(typeValidators).indexOf(type) === -1 ) {
+  if (typeof type !== 'string' || typeof typeValidators[type] !== 'function' ) {
     throw({msg: 'unsupported property type of `' + JSON.stringify(type) + '`.'});
   }
 

--- a/test/adaptors/backbone/base_model_spec.js
+++ b/test/adaptors/backbone/base_model_spec.js
@@ -2154,85 +2154,223 @@ describe('base_model.js special properties', function() {
   });
 });
 describe('base_model.js propTypes functionality', function() {
-  var book, BookModel;
+  var BookModel;
   afterEach(function() {
-    book = null, BookModel = null;
+    BookModel = null;
   });
   /* develblock:start */
-  it('should not warn on initialization correct simple propTypes', function() {
-    spyOn(logger, 'debug').and.callThrough();
+  it('should throw error when PropTypes is not an object', function() {
     BookModel = BaseModel.extend({
       propTypes: {
-        title: 'string',
-        author: 'string',
-        pages: 'number',
-        available: 'boolean'
+        foo: 100,
+        bar: '100',
+        baz: function() {}
       }
     });
-    book = new BookModel({
-      title: 'Midsummer Night\'s Dream',
-      author: 'William Shakespeare',
-      pages: 123,
-      available: true
-    });
-    expect(book.attributes).to.deep.equal({
-      title: 'Midsummer Night\'s Dream',
-      author: 'William Shakespeare',
-      pages: 123,
-      available: true
-    });
-    jasmineExpect(logger.debug).not.toHaveBeenCalled();
+    expect(function() {
+      return new BookModel({
+        author: 'Eric Maria Remarque'
+      });
+    }).throw('PropTypes.foo invalid property descriptor.');
   });
-  it('should log on initialization when setting string to propType number', function() {
-    spyOn(logger, 'debug');
+  it('should not throw an error on initialization for correct simple propTypes', function() {
+    BookModel = BaseModel.extend({
+      propTypes: {
+        title: {
+          type: 'string',
+          required: true
+        },
+        author: {
+          type: 'string'
+        },
+        pages: {
+          type: 'number'
+        },
+        available: {
+          type: 'boolean',
+          required: true
+        },
+        id: {
+          type: 'number',
+          required: false
+        }
+      }
+    });
+    expect(function() {
+      return new BookModel({
+        title: 'Midsummer Night\'s Dream',
+        author: 'William Shakespeare',
+        pages: 123,
+        available: true
+      });
+    }).not.throw();
+  });
+  it('should not throw error when property is not required and not passsed.', function() {
+    BookModel = BaseModel.extend({
+      propTypes: {
+        year: {
+          type: 'number',
+          bar: 'baz',
+          foo: 42
+        }
+      }
+    });
+    expect(function() {
+      return new BookModel({});
+    }).not.throw();
+  });
+  it('should throw an error on initialization when setting string to propType number', function() {
     var attrs = {
       title: 'Midsummer Night\'s Dream'
     };
     BookModel = BaseModel.extend({
       propTypes: {
-        title: 'number'
+        title: {
+          type: 'number'
+        }
       }
     });
-    book = new BookModel(attrs);
-    expect(book.attributes).to.deep.equal({
-      title: 'Midsummer Night\'s Dream'
-    });
-    jasmineExpect(logger.debug).toHaveBeenCalled();
-    expect(logger.debug.calls.argsFor(0)[0]).to.contain('Incorrect propType');
+    expect(function() {
+      return new BookModel(attrs);
+    }).throw('PropTypes.title expected property type of `number`, but got `string`.');
   });
-  it('should log on initialization when setting number to propType string', function() {
-    spyOn(logger, 'debug');
+  it('should throw an error on initialization when setting number to propType string', function() {
     var attrs = {
       pages: 100
     };
     BookModel = BaseModel.extend({
       propTypes: {
-        pages: 'string'
+        pages: {
+          type: 'string'
+        }
       }
     });
-    book = new BookModel(attrs);
-    expect(book.attributes).to.deep.equal({
-      pages: 100
-    });
-    jasmineExpect(logger.debug).toHaveBeenCalled();
-    expect(logger.debug.calls.argsFor(0)[0]).to.contain('Incorrect propType');
+    expect(function() {
+      return new BookModel(attrs);
+    }).throw('PropTypes.pages expected property type of `string`, but got `number`.');
   });
-  it('should log when declaring an invalid propType', function() {
-    spyOn(logger, 'debug');
+  it('should throw an error when declaring an invalid propType', function() {
     var attrs = {
       pages: 100
     };
     BookModel = BaseModel.extend({
       propTypes: {
-        pages: 'bar'
+        pages: {
+          type: 'BloomFilter'
+        }
       }
     });
-    book = new BookModel(attrs);
-    expect(book.attributes).to.deep.equal({
-      pages: 100
+    expect(function() {
+      return new BookModel(attrs);
+    }).throw('PropTypes.pages unsupported property type of `"BloomFilter"`.');
+  });
+  it('should throw an error when declaring required property in propType but not passing it.', function() {
+    BookModel = BaseModel.extend({
+      propTypes: {
+        year: {
+          type: 'number',
+          required: true
+        }
+      }
     });
-    jasmineExpect(logger.debug).toHaveBeenCalled();
-    expect(logger.debug.calls.argsFor(0)[0]).to.contain('Invalid propType');
+    expect(function() {
+      return new BookModel({});
+    }).throw('PropTypes.year was required, but never specified.');
+  });
+  it('should throw an error when passing not supported type in propType.', function() {
+    BookModel = BaseModel.extend({
+      propTypes: {
+        year: {
+          type: null
+        }
+      }
+    });
+    expect(function() {
+      return new BookModel({});
+    }).throw('PropTypes.year unsupported property type of `null`.');
+  });
+  it('should throw an error when passing not supported type in propType.', function() {
+    BookModel = BaseModel.extend({
+      propTypes: {
+        year: {
+          type: []
+        }
+      }
+    });
+    expect(function() {
+      return new BookModel({});
+    }).throw('PropTypes.year unsupported property type of `[]`.');
+  });
+  it('should throw an error when passing not supported type in propType.', function() {
+    BookModel = BaseModel.extend({
+      propTypes: {
+        year: {
+          type: {}
+        }
+      }
+    });
+    expect(function() {
+      return new BookModel({});
+    }).throw('PropTypes.year unsupported property type of `{}`.');
+  });
+  it('should throw an error when passing not supported type in propType.', function() {
+    BookModel = BaseModel.extend({
+      propTypes: {
+        year: {
+          type: undefined
+        }
+      }
+    });
+    expect(function() {
+      return new BookModel({});
+    }).throw('PropTypes.year unsupported property type of `undefined`.');
+  });
+  it('should throw an error when passing not supported type in propType.', function() {
+    BookModel = BaseModel.extend({
+      propTypes: {
+        year: {
+          type: ''
+        }
+      }
+    });
+    expect(function() {
+      return new BookModel({});
+    }).throw('PropTypes.year unsupported property type of `""`.');
+  });
+  it('should throw an error when passing invalid propTypeDesc in propType.', function() {
+    BookModel = BaseModel.extend({
+      propTypes: {
+        year: 'foo'
+      }
+    });
+    expect(function() {
+      return new BookModel({});
+    }).throw('PropTypes.year invalid property descriptor.');
+  });
+  it('should throw an error when passing invalid propTypeDesc in propType.', function() {
+    BookModel = BaseModel.extend({
+      propTypes: {
+        year: 'foo'
+      }
+    });
+    expect(function() {
+      return new BookModel({});
+    }).throw('PropTypes.year invalid property descriptor.');
+  });
+  it('should throw error when property is not required but was passsed with wrong type', function() {
+    BookModel = BaseModel.extend({
+      propTypes: {
+        year: {
+          type: 'number',
+          required: false
+        }
+      }
+    });
+    expect(function() {
+      return new BookModel({
+        year: '42'
+      });
+    }).throw('PropTypes.year expected property type of `number`, but got `string`.');
   });
   /* develblock:end */
 });

--- a/test/adaptors/backbone/base_model_spec.js
+++ b/test/adaptors/backbone/base_model_spec.js
@@ -2323,7 +2323,7 @@ describe('base_model.js propTypes functionality', function() {
     });
     expect(function() {
       return new BookModel({});
-    }).throw('PropTypes.year unsupported property type of `undefined`.');
+    }).throw('PropTypes.year invalid property descriptor.');
   });
   it('should throw an error when passing not supported type in propType.', function() {
     BookModel = BaseModel.extend({
@@ -2361,7 +2361,7 @@ describe('base_model.js propTypes functionality', function() {
     BookModel = BaseModel.extend({
       propTypes: {
         year: {
-          type: 'number',
+          type: null,
           required: false
         }
       }
@@ -2370,7 +2370,7 @@ describe('base_model.js propTypes functionality', function() {
       return new BookModel({
         year: '42'
       });
-    }).throw('PropTypes.year expected property type of `number`, but got `string`.');
+    }).throw('PropTypes.year unsupported property type of `null`.');
   });
   /* develblock:end */
 });


### PR DESCRIPTION
Adds simple checks for PropTypes. Options specified via object with `required` and `type` fields. Props can be `required` without specifying `type` -> will accept any type or no value at all.
