### PR TITLE
Null checking parentView for alternate render outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",

--- a/src/template/adaptor.js
+++ b/src/template/adaptor.js
@@ -165,7 +165,7 @@ function render(stack, template, context, partials, parentView) {
             });
             if (lambdaValue) {
               if (typeof lambdaValue === 'string') {
-                var resultHasClass = parentView && parentView.childViews && lambdaValue.indexOf(' class="') > -1;
+                var resultHasClass = parentView && parentView.childViews && lambdaValue.indexOf(' class=') > -1;
                 var resultHasMustache = lambdaValue.indexOf('{{') > -1;
                 if (resultHasMustache || resultHasClass) {
                   var lambdaTemplateData = compiler(lambdaValue);

--- a/src/template/adaptor.js
+++ b/src/template/adaptor.js
@@ -165,7 +165,7 @@ function render(stack, template, context, partials, parentView) {
             });
             if (lambdaValue) {
               if (typeof lambdaValue === 'string') {
-                var resultHasClass = lambdaValue.indexOf(' class="') > -1 && parentView.childViews;
+                var resultHasClass = parentView && parentView.childViews && lambdaValue.indexOf(' class="') > -1;
                 var resultHasMustache = lambdaValue.indexOf('{{') > -1;
                 if (resultHasMustache || resultHasClass) {
                   var lambdaTemplateData = compiler(lambdaValue);


### PR DESCRIPTION
Right now lambdas with content only work if rendered via Vdom output. This properly skips child view attachment if parentView is not set.