### PR TITLE
Changing Widget.init to use dynamicInitialize to mirror ComponentWidget

### DIFF
--- a/adaptors/ampersand/ampersand_view_widget.js
+++ b/adaptors/ampersand/ampersand_view_widget.js
@@ -62,13 +62,11 @@ AmpersandViewWidget.prototype.type = 'Widget';
  * @return {Element} DOM node with the child view attached
  */
 AmpersandViewWidget.prototype.init = function init() {
-  var elem = this.template.toDom(this.context);
   this.view = new this.ViewConstructor({
     template: this.template,
     model: this.model,
     context: this.context,
-    // Since we can't attach a view to a DocumentFragment, pull out firstChild
-    el: elem,
+    dynamicInitialize: true,
     parentView: this.parentView
   });
   return this.view.el;

--- a/adaptors/backbone/backbone_view_widget.js
+++ b/adaptors/backbone/backbone_view_widget.js
@@ -62,13 +62,12 @@ BackboneViewWidget.prototype.type = 'Widget';
  * @return {Element} DOM node with the child view attached
  */
 BackboneViewWidget.prototype.init = function init() {
-  var elem = this.template.toDom(this.context);
   this.view = new this.ViewConstructor({
     template: this.template,
     model: this.model,
     context: this.context,
-    el: elem,
-    parentView: this.parentView
+    parentView: this.parentView,
+    dynamicInitialize: true
   });
   return this.view.el;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tungstenjs",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",

--- a/test/adaptors/ampersand/ampersand_view_widget_spec.js
+++ b/test/adaptors/ampersand/ampersand_view_widget_spec.js
@@ -107,22 +107,18 @@ describe('ampersand_view_widget public api', function() {
     it('should construct from the template\'s DOM and return the element', function() {
       // template.toDom returns a documentFragment
       var elem = {};
-      var template = {
-        toDom: jasmine.createSpy('toDom').and.returnValue(elem)
-      };
       var expectedView;
       var ViewConstructor = jasmine.createSpy('ViewConstructor').and.callFake(function (args) {
         expectedView = args;
+        args.el = elem;
         return args;
       });
       var ctx = {
         ViewConstructor: ViewConstructor,
-        context: {},
-        template: template
+        context: {}
       };
       var result = AmpersandViewWidget.prototype.init.call(ctx);
       expect(result).to.equal(elem);
-      jasmineExpect(template.toDom).toHaveBeenCalledWith(ctx.context);
       jasmineExpect(ViewConstructor).toHaveBeenCalled();
       expect(ctx.view).to.equal(expectedView);
     });

--- a/test/adaptors/backbone/backbone_view_widget_spec.js
+++ b/test/adaptors/backbone/backbone_view_widget_spec.js
@@ -107,22 +107,18 @@ describe('backbone_view_widget public api', function() {
     it('should construct from the template\'s DOM and return the element', function() {
       // template.toDom returns a documentFragment
       var elem = {};
-      var template = {
-        toDom: jasmine.createSpy('toDom').and.returnValue(elem)
-      };
       var expectedView;
       var ViewConstructor = jasmine.createSpy('ViewConstructor').and.callFake(function (args) {
         expectedView = args;
+        args.el = elem;
         return args;
       });
       var ctx = {
         ViewConstructor: ViewConstructor,
-        context: {},
-        template: template
+        context: {}
       };
       var result = BackboneViewWidget.prototype.init.call(ctx);
       expect(result).to.equal(elem);
-      jasmineExpect(template.toDom).toHaveBeenCalledWith(ctx.context);
       jasmineExpect(ViewConstructor).toHaveBeenCalled();
       expect(ctx.view).to.equal(expectedView);
     });


### PR DESCRIPTION
Fixes an issue where the childView's vtree was compiled with its given model rather than the current render context. Also prevents a duplicate render for toDom and then toVdom