### PR TITLE
Add tungsten's template compiler to the toplevel of the UMD

### DIFF
--- a/adaptors/ampersand/index.js
+++ b/adaptors/ampersand/index.js
@@ -28,8 +28,9 @@ module.exports = {
     View: require('ampersand-view')
   },
   _: require('underscore'),
-  Template: require('../../src/template/template.js'),
+  Template: require('../../src/template/template'),
   addEventPlugin: tungsten.addEventPlugin,
   _core: tungsten,
-  _template: require('../../precompile/tungsten_template/template_helper')
+  _template: require('../../precompile/tungsten_template/template_helper'),
+  compiler: require('../../precompile/tungsten_template')
 };

--- a/adaptors/backbone/index.js
+++ b/adaptors/backbone/index.js
@@ -26,9 +26,10 @@ module.exports = {
   Backbone: require('backbone'),
   _: require('underscore'),
   ComponentWidget: require('./component_widget'),
-  Template: require('../../src/template/template.js'),
+  Template: require('../../src/template/template'),
   addEventPlugin: tungsten.addEventPlugin,
   _core: tungsten,
   _template: require('../../precompile/tungsten_template/template_helper'),
+  compiler: require('../../precompile/tungsten_template'),
   _Context: Context
 };

--- a/src/event/handlers/change_events.js
+++ b/src/event/handlers/change_events.js
@@ -21,7 +21,7 @@ var changeDoesNotBubble = (function() {
   d.setAttribute('onchange', 't');
   if (typeof d.attributes === 'undefined') {
     // Element.attributes is undefined in an node environment
-    return;
+    return true;
   }
   return d.attributes.onchange && d.attributes.onchange.expando === true;
 })();

--- a/src/event/handlers/change_events.js
+++ b/src/event/handlers/change_events.js
@@ -19,6 +19,10 @@ var changeDoesNotBubble = (function() {
   // @license MIT
   var d = document.createElement('div');
   d.setAttribute('onchange', 't');
+  if (typeof d.attributes === 'undefined') {
+    // Element.attributes is undefined in an node environment
+    return;
+  }
   return d.attributes.onchange && d.attributes.onchange.expando === true;
 })();
 

--- a/src/tungsten.js
+++ b/src/tungsten.js
@@ -52,7 +52,9 @@ function updateTree(container, initialTree, newTree) {
 /* develblock:start */
 exports.debug = require('./debug');
 // Override toJSON for DOM nodes to prevent circular references in debug mode
-window.Element.prototype.toJSON = function() {return null;};
+window.Element.prototype.toJSON = function() {
+  return null;
+};
 /* develblock:end */
 
 exports.parseString = function (htmlString) {

--- a/webpack.standalone.js
+++ b/webpack.standalone.js
@@ -38,6 +38,7 @@ module.exports = webpackSettings.compileSource({
     libraryTarget: 'umd',
     library: 'tungsten'
   },
+  target: 'node',
   resolve: {
     alias: {
       jquery: path.join(__dirname, './src/polyfill/jquery')


### PR DESCRIPTION
### Changes

- Compile for usage in a node.js-like environment
  See: https://webpack.github.io/docs/configuration.html#target

  Increases bundle size as it includes modules (like min-document) that would be
  left out of a brower targeted build.

- min-document does not support the full DOM API.  Added a check where
  necessary.