### PR TITLE
Template attach bug

### DIFF
--- a/src/template/adaptor.js
+++ b/src/template/adaptor.js
@@ -280,12 +280,15 @@ var attachView = function(view, template, createWidget, partials, childClasses) 
 
   // Arrays need iterating over
   if (Context.isArray(template)) {
+    var clone = new Array(template.length);
     for (i = 0; i < template.length; i++) {
-      template[i] = attachView(view, template[i], createWidget, partials, childClasses);
+      clone[i] = attachView(view, template[i], createWidget, partials, childClasses);
     }
     // short circuit
-    return template;
+    return clone;
   }
+
+  template = _.clone(template);
 
   /* eslint-disable dot-notation */
   // If the view has childViews and this isn't the root, attempt to attach Widget
@@ -315,11 +318,7 @@ var attachView = function(view, template, createWidget, partials, childClasses) 
 
   // Recurse on any child elements
   if (template.f) {
-    for (i = 0; i < template.f.length; i++) {
-      template.f[i] = attachView(view, template.f[i], createWidget, partials, childClasses);
-    }
-    // in the event of a partial, we may get a nested array, this flattens it out
-    template.f = _.flatten(template.f, true);
+    template.f = attachView(view, template.f, createWidget, partials, childClasses);
   }
 
   // If this is a partial, lookup and recurse
@@ -335,7 +334,7 @@ var attachView = function(view, template, createWidget, partials, childClasses) 
       }
       template = attachView(
         view,
-        _.clone(partialTemplate),
+        partialTemplate,
         createWidget,
         partials[partialName].partials || partials,
         childClasses

--- a/src/template/template.js
+++ b/src/template/template.js
@@ -121,7 +121,7 @@ Template.prototype.attachView = function(view, widgetWrapper) {
     widgetConstructor = widgetWrapper;
   }
   var templateObj = templateAdaptor.attach(
-    _.clone(this.templateObj),
+    this.templateObj,
     view,
     createChildView,
     this.getPartials()

--- a/src/template/template.js
+++ b/src/template/template.js
@@ -5,7 +5,6 @@
  */
 'use strict';
 
-var _ = require('underscore');
 var templateAdaptor = require('./adaptor');
 var Context = require('./template_context');
 

--- a/src/tungsten.js
+++ b/src/tungsten.js
@@ -52,7 +52,9 @@ function updateTree(container, initialTree, newTree) {
 /* develblock:start */
 exports.debug = require('./debug');
 // Override toJSON for DOM nodes to prevent circular references in debug mode
-window.Element.prototype.toJSON = function() {return null;};
+window.Element.prototype.toJSON = function() {
+  return null;
+};
 /* develblock:end */
 
 exports.parseString = function (htmlString) {

--- a/test/src/template/template_spec.js
+++ b/test/src/template/template_spec.js
@@ -212,10 +212,12 @@ describe('attachView', function() {
     var template1 = getTemplate('<div class="js-child"></div>');
     var template2 = getTemplate('<div><div class="js-child"></div></div>');
     var template3 = getTemplate('{{#foo}}<div class="js-child"></div>{{/foo}}');
-    var template4 = getTemplate('<div>{{>partial}}</div>', {partial:'<div><div class="js-child"></div></div>'});
+    var template4 = getTemplate('<div>{{>partial}}</div>', {partial: '<div><div class="js-child"></div></div>'});
     var template4Partial = template4.partials.partial;
 
-    var widgetConstructor = function() { return {}; };
+    var widgetConstructor = function() {
+      return {};
+    };
     var childView = function() {};
     childView.tungstenView = true;
     var view = {
@@ -225,10 +227,10 @@ describe('attachView', function() {
       }
     };
 
-    var output1 = template1.attachView(view, fakeWidgetConstructor);
-    var output2 = template2.attachView(view, fakeWidgetConstructor);
-    var output3 = template3.attachView(view, fakeWidgetConstructor);
-    var output4 = template4.attachView(view, fakeWidgetConstructor);
+    var output1 = template1.attachView(view, widgetConstructor);
+    var output2 = template2.attachView(view, widgetConstructor);
+    var output3 = template3.attachView(view, widgetConstructor);
+    var output4 = template4.attachView(view, widgetConstructor);
 
     expect(output1.templateObj[0].type).to.equal('WidgetConstructor');
     expect(template1.templateObj[0].t).to.equal(types.ELEMENT);

--- a/test/src/template/template_spec.js
+++ b/test/src/template/template_spec.js
@@ -207,4 +207,24 @@ describe('attachView', function() {
     var output = template.attachView(template2.view, fakeWidgetConstructor);
     expect(output.view).to.deep.equal(template2.view);
   });
+  it('should not modify the original template', function() {
+    var template1 = getTemplate('<div class="js-child"></div>');
+    var template2 = getTemplate('<div><div class="js-child"></div></div>');
+    var widgetConstructor = function() { return {}; };
+    var childView = function() {};
+    childView.tungstenView = true;
+    var view = {
+      el: {nodeName: false},
+      childViews: {
+        'js-child': childView
+      }
+    };
+
+    var output1 = template1.attachView(view, fakeWidgetConstructor);
+    var output2 = template2.attachView(view, fakeWidgetConstructor);
+    expect(template1.templateObj[0].t).to.equal(7);
+    expect(output1.templateObj[0].type).to.equal('WidgetConstructor');
+    expect(template2.templateObj[0].f[0].t).to.equal(7);
+    expect(output2.templateObj[0].f[0].type).to.equal('WidgetConstructor');
+  });
 });


### PR DESCRIPTION
When attaching child views, the original template was being modified in place.
This fixes the issue so that the original template object is unchanged by the process.