### PR TITLE
ToDom fix

### DIFF
--- a/adaptors/backbone/base_model.js
+++ b/adaptors/backbone/base_model.js
@@ -492,24 +492,24 @@ BaseModel.prototype.validateProperty = function (propTypeDesc, propValue) {
 
   // check if propTypeDesc is an object and has at least one valid attribute
   if (typeof propTypeDesc !== 'object' || !hasAtLeastOneKey(propTypeDesc, validDescAttrs)) {
-    throw({msg: 'invalid property descriptor.'});
+    return {msg: 'invalid property descriptor.'};
   }
 
   // validate property type only when it was specified and is a string
   if (typeof type !== 'string' || typeof typeValidators[type] !== 'function' ) {
-    throw({msg: 'unsupported property type of `' + JSON.stringify(type) + '`.'});
+    return {msg: 'unsupported property type of `' + JSON.stringify(type) + '`.'};
   }
 
   if (isRequired) {
     if (propValue === undefined) {
-      throw({msg: 'was required, but never specified.'});
+      return {msg: 'was required, but never specified.'};
     }
     if (type && !typeValidators[type](propValue)) {
-      throw({msg: 'expected property type of `' + type + '`, but got `' + propValueType + '`.'});
+      return {msg: 'expected property type of `' + type + '`, but got `' + propValueType + '`.'};
     }
   } else {
     if (propValue && type && !typeValidators[type](propValue)) {
-      throw({msg: 'expected property type of `' + type + '`, but got `' + propValueType + '`.'});
+      return {msg: 'expected property type of `' + type + '`, but got `' + propValueType + '`.'};
     }
   }
   return true;
@@ -535,10 +535,9 @@ BaseModel.prototype.set = function(key, val, options) {
   // iterate though properties and check if valid
   _.each(propTypes, (propType, propName) => {
     var propValue = attrs[propName];
-    try {
-      this.validateProperty(propType, propValue);
-    } catch (err) {
-      throw new TypeError('PropTypes.' + propName + ' ' + err.msg);
+    var validationResult = this.validateProperty(propType, propValue);
+    if (validationResult !== true) {
+      throw new TypeError('PropTypes.' + propName + ' ' + validationResult.msg);
     }
   });
 

--- a/src/template/stacks/default.js
+++ b/src/template/stacks/default.js
@@ -122,7 +122,10 @@ DefaultStack.prototype._closeElem = function(obj) {
     pushingTo = this.result;
   }
 
-  // Combine adjacent strings
+  this.appendItem(pushingTo, obj);
+};
+
+DefaultStack.prototype.appendItem = function(pushingTo, obj) {
   if (typeof obj === 'string' && typeof pushingTo[pushingTo.length - 1] === 'string') {
     pushingTo[pushingTo.length - 1] += obj;
   } else {

--- a/src/template/stacks/dom.js
+++ b/src/template/stacks/dom.js
@@ -59,6 +59,23 @@ DomStack.prototype.processObject = function(obj) {
   }
 };
 
+DomStack.prototype.appendItem = function(pushingTo, obj) {
+  var lastItem = pushingTo[pushingTo.length - 1];
+  var lastItemIsText = lastItem && lastItem.nodeType === 3;
+  if (typeof obj === 'string' && typeof lastItem === 'string') {
+    // string/string
+    pushingTo[pushingTo.length - 1] += obj;
+  } else if (typeof obj === 'string' && lastItemIsText) {
+    // textNode/string
+    pushingTo[pushingTo.length - 1].nodeValue += obj;
+  } else if (obj.nodeType === 3 && lastItemIsText) {
+    // textNode/textNode
+    pushingTo[pushingTo.length - 1].nodeValue += obj.nodeValue;
+  } else {
+    pushingTo.push(obj);
+  }
+};
+
 DomStack.prototype.createObject = function(obj, options) {
   if (isWidget(obj)) {
     obj.template._iterate(null, obj.model, null, null, this);

--- a/test/src/template/stacks/default_spec.js
+++ b/test/src/template/stacks/default_spec.js
@@ -1,6 +1,6 @@
 var DefaultStack = require('../../../../src/template/stacks/default');
 
-define('default_stack private functions', function() {
+describe('default_stack private functions', function() {
   describe('doesSupportWhitespaceTextNodes', function() {
     it('should be a function', function() {
       expect(DefaultStack.doesSupportWhitespaceTextNodes).to.be.a('function');

--- a/test/src/template/stacks/dom_spec.js
+++ b/test/src/template/stacks/dom_spec.js
@@ -1,6 +1,6 @@
 var DomStack = require('../../../../src/template/stacks/dom');
 var compiler = require('../../../../precompile/tungsten_template/inline');
-define('DomStack', function() {
+describe('DomStack', function() {
   it('should be a function', function() {
     expect(DomStack).to.be.a('function');
     expect(DomStack).to.have.length(2);

--- a/test/src/template/stacks/dom_spec.js
+++ b/test/src/template/stacks/dom_spec.js
@@ -1,0 +1,20 @@
+var DomStack = require('../../../../src/template/stacks/dom');
+var compiler = require('../../../../precompile/tungsten_template/inline');
+define('DomStack', function() {
+  it('should be a function', function() {
+    expect(DomStack).to.be.a('function');
+    expect(DomStack).to.have.length(2);
+  });
+  it('should flatten strings', function() {
+    // Adding Mustache comment to compile template without needed lookup data
+    var template = compiler(`<div>\nasdf\n{{!foo}}\n\n</div>`);
+    var output = template.toDom({});
+    expect(output.nodeType).to.equal(1); // 1 === Node.ELEMENT_NODE
+    expect(output.childNodes.length).to.equal(1);
+  });
+  it('should flatten top level strings', function() {
+    var template = compiler(`\nasdf\n{{!foo}}\n\n`);
+    var output = template.toDom({});
+    expect(output.nodeType).to.equal(3); // 3 === Node.TEXT_NODE
+  });
+});

--- a/test/src/template/stacks/vdom_spec.js
+++ b/test/src/template/stacks/vdom_spec.js
@@ -1,6 +1,6 @@
 var VdomStack = require('../../../../src/template/stacks/vdom');
 var tungsten = require('../../../../src/tungsten');
-define('processObject', function() {
+describe('processObject', function() {
   var stack, props, children;
   beforeEach(function() {
     stack = new VdomStack(), props = {}, children = [{}];


### PR DESCRIPTION
the Dom stack was improperly concatenating top level strings as they were being transformed into textNodes first which was not handled.

Broke the concatenation functionality into a new function for the Default stack and overrode it for the Dom stack to better handle these cases.

Fixed unit tests referencing "define" instead of "describe".
Fixed  eslint warnings from new propType code