### PR TITLE
Adding function to update child-less view without rendering

### DIFF
--- a/adaptors/backbone/base_view.js
+++ b/adaptors/backbone/base_view.js
@@ -147,6 +147,13 @@ var BaseView = Backbone.View.extend({
    */
   postInitialize: function() {},
 
+  updateVtree: function() {
+    if (this.vtree.hasWidgets) {
+      throw 'Views with childViews cannot be updated with this method.';
+    }
+    this.vtree = this.compiledTemplate.toVdom(this.serialize());
+  },
+
   validateVdom: function() {
     // If the vtree or element hasn't been set for any reason, bail out of validation
     if (!this.vtree || !this.vtree.children || !this.el || !this.el.childNodes) {

--- a/adaptors/backbone/base_view.js
+++ b/adaptors/backbone/base_view.js
@@ -148,7 +148,7 @@ var BaseView = Backbone.View.extend({
   postInitialize: function() {},
 
   updateVtree: function() {
-    if (this.vtree.hasWidgets) {
+    if (this.childViews && _.size(this.childViews) > 0) {
       throw 'Views with childViews cannot be updated with this method.';
     }
     this.vtree = this.compiledTemplate.toVdom(this.serialize());

--- a/test/adaptors/backbone/base_view_spec.js
+++ b/test/adaptors/backbone/base_view_spec.js
@@ -751,6 +751,49 @@ describe('base_view.js constructed api', function() {
         done();
       }, 1);
     });
+    describe('updateVtree', function() {
+      var model, template, view;
+      beforeEach(function() {
+        model = {};
+        template = {
+          toVdom: jasmine.createSpy('toVdom')
+        };
+        view = {
+          compiledTemplate: template,
+          serialize: function() {
+            return model;
+          }
+        };
+      });
+      afterEach(function() {
+        model = template = view = null;
+      });
+
+      it('should be allowed to call with no childViews', function() {
+        expect(function() {
+          BaseView.prototype.updateVtree.call(view);
+        }).not.to.throw();
+        jasmineExpect(template.toVdom).toHaveBeenCalledWith(model);
+      });
+
+      it('should be allowed to call with an empty childViews', function() {
+        view.childViews = {};
+        expect(function() {
+          BaseView.prototype.updateVtree.call(view);
+        }).not.to.throw();
+        jasmineExpect(template.toVdom).toHaveBeenCalledWith(model);
+      });
+
+      it('should not be allowed to call with a populated childViews', function() {
+        view.childViews = {
+          'js-foo': _.noop
+        };
+        expect(function() {
+          BaseView.prototype.updateVtree.call(view);
+        }).to.throw();
+        jasmineExpect(template.toVdom).not.toHaveBeenCalled();
+      });
+    });
   });
 
 });


### PR DESCRIPTION
Adding a function to silently update the vtree for child-less views.
This allows for bottom level views (like lazy-loaded images or inputs) to update their DOM manually or via user-input, while keeping the vtree in sync without a rerender