### PR TITLE
Attribute escape fix

### DIFF
--- a/src/template/stacks/string.js
+++ b/src/template/stacks/string.js
@@ -2,6 +2,7 @@
 
 var DefaultStack = require('./default');
 var htmlParser = require('../html_parser');
+var escapeString = require('../../utils/escape_string');
 
 function StringStack(attributesOnly, noParse) {
   DefaultStack.call(this, attributesOnly);
@@ -18,6 +19,8 @@ StringStack.prototype.createObject = function(obj, options) {
     } else {
       this._closeElem(obj);
     }
+  } else if (this.noParse && typeof obj === 'string' && options && options.escape) {
+    this._closeElem(escapeString(obj));
   } else {
     this._closeElem(obj);
   }

--- a/test/src/template/stacks/string_value_spec.js
+++ b/test/src/template/stacks/string_value_spec.js
@@ -44,15 +44,29 @@ describe('debug_value spec', function() {
     };
     expect(fn).to.throw();
   });
-  it('should not error if a html is not encountered inside a unescaped interpolator', function() {
+  it('should not error if html is not encountered inside a unescaped interpolator', function() {
     var compiledTemplate = compiler('{{{ foo }}} & {{{ bar }}}');
     var data = {
       foo: 'bar < foo',
       bar: 'foo < bar'
     };
+    var stack = new StringStack();
     var fn = function() {
-      compiledTemplate.template._iterate(null, data, null, null, new StringStack());
+      compiledTemplate.template._iterate(null, data, null, null, stack);
     };
     expect(fn).not.to.throw();
+    expect(stack.getOutput()).to.equal(data.foo + ' & ' + data.bar);
+  });
+  it('should escape', function() {
+    var compiledTemplate = compiler('{{foo}}');
+    var data = { foo: '&' };
+    var output = compiledTemplate.template._render(null, data, null, null, new StringStack());
+    expect(output).to.equal('&amp;');
+  });
+  it('should parse', function() {
+    var compiledTemplate = compiler('{{{foo}}}');
+    var data = { foo: '&' };
+    var output = compiledTemplate.template._render(null, data, null, null, new StringStack());
+    expect(output).to.equal('&');
   });
 });

--- a/test/src/template/stacks/string_value_spec.js
+++ b/test/src/template/stacks/string_value_spec.js
@@ -60,7 +60,12 @@ describe('debug_value spec', function() {
   it('should escape', function() {
     var compiledTemplate = compiler('{{foo}}');
     var data = { foo: '&' };
+    // if noParse is left false, it's being used to render static attribute values and should not escape anything
     var output = compiledTemplate.template._render(null, data, null, null, new StringStack());
+    expect(output).to.equal('&');
+
+    // if noParse is set to true, it's being used to render dynamic attribute values and should escape
+    output = compiledTemplate.template._render(null, data, null, null, new StringStack(true, true));
     expect(output).to.equal('&amp;');
   });
   it('should parse', function() {


### PR DESCRIPTION
Interpolators in attribute values within sections were not being escaped before being parsed, which lead to odd errors.