### PR TITLE
Treating autocorrect as an attribute

### DIFF
--- a/src/template/process_properties.js
+++ b/src/template/process_properties.js
@@ -10,7 +10,6 @@ var nonTransformedProperties = {
   'async': true,
   'autocapitalize': true,
   'autocomplete': true,
-  'autocorrect': true,
   'autoplay': true,
   'checked': true,
   'content': true,


### PR DESCRIPTION
This attribute was mistakenly on the list of properties, but should be used as an attribute.