### PR TITLE
String attribute fix

### DIFF
--- a/src/template/stacks/html_string.js
+++ b/src/template/stacks/html_string.js
@@ -35,6 +35,11 @@ HtmlStringStack.prototype.processObject = function(obj) {
       if (typeof value === 'boolean') {
         htmlStr += ' ' + name;
       } else if (value != null) {
+        if (typeof value === 'string') {
+          // Virtual-dom or the DOM normally handles escaping attribute values
+          // but that doesn't come into play here, so we need to escape ourselves
+          value = escapeString(value);
+        }
         htmlStr += ' ' + name + '="' + value + '"';
       }
     });

--- a/test/src/template/stacks/html_string_spec.js
+++ b/test/src/template/stacks/html_string_spec.js
@@ -1,0 +1,60 @@
+var compiler = require('../../../../src/template/compiler/index');
+var HtmlStringStack = require('../../../../src/template/stacks/html_string');
+var Context = require('../../../../src/template/template_context');
+
+Context.setAdapterFunctions({
+  initialize: function(view, parentContext) {
+    if (view == null) {
+      view = {};
+    }
+    this.parent = parentContext;
+  },
+  lookupValue: function(view, name) {
+    var value = null;
+    if (view && view[name] != null) {
+      value = view[name];
+    }
+
+    return value;
+  }
+});
+
+describe('attribute values spec', function() {
+  it('should output attribute values', function() {
+    var compiledTemplate = compiler('<div data-test="{{foo}}"></div>');
+    var stack = new HtmlStringStack();
+    compiledTemplate.template._iterate(null, {foo: 'test'}, null, null, stack);
+    var output = stack.getOutput();
+    expect(output).to.equal('<div data-test="test"></div>');
+  });
+  it('should escape quotes in attribute values', function() {
+    var compiledTemplate = compiler('<div data-test="{{foo}}"></div>');
+    var stack = new HtmlStringStack();
+    compiledTemplate.template._iterate(null, {foo: '{"test":1}'}, null, null, stack);
+    var output = stack.getOutput();
+    expect(output).to.equal('<div data-test="{&quot;test&quot;:1}"></div>');
+  });
+
+  it('should output property values', function() {
+    var compiledTemplate = compiler('<input value="{{foo}}">');
+    var stack = new HtmlStringStack();
+    compiledTemplate.template._iterate(null, {foo: 'test'}, null, null, stack);
+    var output = stack.getOutput();
+    expect(output).to.equal('<input value="test">');
+  });
+  it('should escape quotes in property values', function() {
+    var compiledTemplate = compiler('<input value="{{foo}}">');
+    var stack = new HtmlStringStack();
+    compiledTemplate.template._iterate(null, {foo: '{"test":1}'}, null, null, stack);
+    var output = stack.getOutput();
+    expect(output).to.equal('<input value="{&quot;test&quot;:1}">');
+  });
+
+  it('should escape quotes in loose text', function() {
+    var compiledTemplate = compiler('<div>{{foo}}</div>');
+    var stack = new HtmlStringStack();
+    compiledTemplate.template._iterate(null, {foo: '{"test":1}'}, null, null, stack);
+    var output = stack.getOutput();
+    expect(output).to.equal('<div>{&quot;test&quot;:1}</div>');
+  });
+});


### PR DESCRIPTION
When compiling to HTML string output, characters that are normally encoded via virtual-dom or DOM methods were left unencoded, resulting in potentially invalid HTML output. This ensures that attribute values are properly encoded