### PR TITLE
Add readme notes on building dist files before running for examples

### DIFF
--- a/examples/dbmonster-component/readme.md
+++ b/examples/dbmonster-component/readme.md
@@ -4,7 +4,7 @@ Example implementation of Ryan Florance's [DBMonster](https://github.com/ryanflo
 
 ## Run
 
-    # Run `npm install` on the main tungstenjs directory
+    # run `npm install && npm run dist` on the main tungstenjs directory
     npm install
     npm start
     # To run in debug mode: `npm start -- --dev`

--- a/examples/dbmonster/readme.md
+++ b/examples/dbmonster/readme.md
@@ -4,7 +4,7 @@ Example implementation of Ryan Florance's [DBMonster](https://github.com/ryanflo
 
 ## Run
 
-    # Run `npm install` on the main tungstenjs directory
+    # run `npm install && npm run dist` on the main tungstenjs directory
     npm install
     npm start
     # To run in debug mode: `npm start -- --dev`

--- a/examples/drag-and-drop/readme.md
+++ b/examples/drag-and-drop/readme.md
@@ -4,7 +4,7 @@ Example integrating [dragula](https://github.com/bevacqua/dragula) with Tungsten
 
 ## Run
 
-    # Run `npm install` on the main tungstenjs directory
+    # run `npm install && npm run dist` on the main tungstenjs directory
     npm install
     npm start
     # To run in debug mode: `npm start -- --dev`

--- a/examples/svg/readme.md
+++ b/examples/svg/readme.md
@@ -4,7 +4,7 @@ Example application showing how Tungsten.js can be used with SVG.
 
 ## Run
 
-    # Run `npm install` on the main tungstenjs directory
+    # run `npm install && npm run dist` on the main tungstenjs directory
     npm install
     npm start
     # To run in debug mode: `npm start -- --dev`

--- a/examples/todomvc-components/readme.md
+++ b/examples/todomvc-components/readme.md
@@ -4,7 +4,7 @@ Example application showing how [TodoMVC](http://todomvc.com/) can be implemente
 
 ## Run
 
-    # Run `npm install` on the main tungstenjs directory
+    # run `npm install && npm run dist` on the main tungstenjs directory
     npm install
     npm start
     # To run in debug mode: `npm start -- --dev`

--- a/examples/todomvc-es6+/readme.md
+++ b/examples/todomvc-es6+/readme.md
@@ -4,7 +4,7 @@ Example application showing how [TodoMVC](http://todomvc.com/) can be implemente
 
 ## Run
 
-    # Run `npm install` on the main tungstenjs directory
+    # run `npm install && npm run dist` on the main tungstenjs directory
     npm install
     npm start
     # To run in debug mode: `npm start -- --dev`

--- a/examples/todomvc/readme.md
+++ b/examples/todomvc/readme.md
@@ -4,7 +4,7 @@ Example application showing how [TodoMVC](http://todomvc.com/) can be implemente
 
 ## Run
 
-    # Run `npm install` on the main tungstenjs directory
+    # run `npm install && npm run dist` on the main tungstenjs directory
     npm install
     npm start
     # To run in debug mode: `npm start -- --dev`

--- a/gh_pages/readme.md
+++ b/gh_pages/readme.md
@@ -3,7 +3,7 @@
 ## Build and Publish
 
 ```
-# Run `npm install` on the main tungstenjs directory
+# run `npm install && npm run dist` on the main tungstenjs directory
 npm install
 npm run build
 # built site will be at `../output`


### PR DESCRIPTION
# Overview

If the dist files aren't built, then the examples won't run.  This clarifies the install instructions since dist files aren't built with `npm install` alone.