### PR TITLE
Context lookup fallback fix

### DIFF
--- a/adaptors/backbone/context_adaptor.js
+++ b/adaptors/backbone/context_adaptor.js
@@ -65,7 +65,7 @@ var lookupValue = function(view, name) {
     return view.at(name);
   }
   // Fall back to a property check
-  if (view.hasOwnProperty(name)) {
+  if (view[name] != null && typeof view === 'object') {
     if (view.tungstenCollection && blockedCollectionProperties[name]) {
       return null;
     }

--- a/adaptors/backbone/context_adaptor.js
+++ b/adaptors/backbone/context_adaptor.js
@@ -65,7 +65,7 @@ var lookupValue = function(view, name) {
     return view.at(name);
   }
   // Fall back to a property check
-  if (view[name] != null) {
+  if (view.hasOwnPropery(name)) {
     if (view.tungstenCollection && blockedCollectionProperties[name]) {
       return null;
     }

--- a/adaptors/backbone/context_adaptor.js
+++ b/adaptors/backbone/context_adaptor.js
@@ -65,7 +65,7 @@ var lookupValue = function(view, name) {
     return view.at(name);
   }
   // Fall back to a property check
-  if (view.hasOwnPropery(name)) {
+  if (view.hasOwnProperty(name)) {
     if (view.tungstenCollection && blockedCollectionProperties[name]) {
       return null;
     }


### PR DESCRIPTION
# Overview

Fixes fallback lookups in Backbone's context adaptor

## Details

 When using fallback branch, check if property belongs to current view

