### PR TITLE
Fix memory leak in tutorial/sandbox

### DIFF
--- a/gh_pages/js/helpers.js
+++ b/gh_pages/js/helpers.js
@@ -77,55 +77,5 @@ var helpers = {
         this.run();
         return false;
       }
-    },
-    // fn for initializing tungsten app environment for sandbox/tutorial pages
-    initTungsten: function(tungsten, _) {
-      tungsten.plugins.event.all.forEach(tungsten.addEventPlugin);
-      var runtimeObjects = [];
-      tungsten.View.prototype._initialize = tungsten.View.prototype.initialize;
-      tungsten.View.prototype.initialize = function(opts) {
-        if (!opts.parentView && !this.appObj) {
-          runtimeObjects.push(this);
-        }
-        this._initialize(opts);
-      };
-      tungsten.Model.prototype._initialize = tungsten.Model.prototype.initialize;
-      tungsten.Model.prototype.initialize = function(attributes, opts) {
-        opts = opts || {};
-        if (!this.appObj) {
-          runtimeObjects.push(this);
-        }
-        this._initialize(opts);
-      };
-      tungsten.Collection.prototype._initialize = tungsten.Collection.prototype.initialize;
-      tungsten.Collection.prototype.initialize = function(models, opts) {
-        opts = opts || {};
-        if (!this.appObj) {
-          runtimeObjects.push(this);
-        }
-        this._initialize(opts);
-      };
-
-      var View = tungsten.View.extend({
-        initDebug: _.noop,
-        _setElement: tungsten.Backbone.View.prototype._setElement,
-        appObj: true
-      });
-      var Model = tungsten.Model.extend({
-        initDebug: _.noop,
-        appObj: true
-      });
-      var Collection = tungsten.Collection.extend({
-        initDebug: _.noop,
-        appObj: true
-      });
-      var ComponentWidget = tungsten.ComponentWidget;
-      return {
-        runtimeObjects: runtimeObjects,
-        View: View,
-        Model: Model,
-        Collection: Collection,
-        ComponentWidget: ComponentWidget
-      };
     }
   };

--- a/gh_pages/js/sandbox_app.js
+++ b/gh_pages/js/sandbox_app.js
@@ -1,11 +1,45 @@
 (function(CodeMirror, _, tungsten, helpers) {
   'use strict';
-  var tungstenEnv = helpers.initTungsten(tungsten, _);
-  var runtimeObjects = tungstenEnv.runtimeObjects;
-  var View = tungstenEnv.View;
-  var Model = tungstenEnv.Model;
-  var Collection = tungstenEnv.Collection;
-  var ComponentWidget = tungstenEnv.ComponentWidget;
+  tungsten.plugins.event.all.forEach(tungsten.addEventPlugin);
+  var runtimeObjects = [];
+  tungsten.View.prototype._initialize = tungsten.View.prototype.initialize;
+  tungsten.View.prototype.initialize = function(opts) {
+    if (!opts.parentView && !this.tutorialObj) {
+      runtimeObjects.push(this);
+    }
+    this._initialize(opts);
+  };
+  tungsten.Model.prototype._initialize = tungsten.Model.prototype.initialize;
+  tungsten.Model.prototype.initialize = function(attributes, opts) {
+    opts = opts || {};
+    if (!this.tutorialObj) {
+      runtimeObjects.push(this);
+    }
+    this._initialize(opts);
+  };
+  tungsten.Collection.prototype._initialize = tungsten.Collection.prototype.initialize;
+  tungsten.Collection.prototype.initialize = function(models, opts) {
+    opts = opts || {};
+    if (!this.tutorialObj) {
+      runtimeObjects.push(this);
+    }
+    this._initialize(opts);
+  };
+
+  var View = tungsten.View.extend({
+    initDebug: _.noop,
+    _setElement: tungsten.Backbone.View.prototype._setElement,
+    tutorialObj: true
+  });
+  var Model = tungsten.Model.extend({
+    initDebug: _.noop,
+    tutorialObj: true
+  });
+  var Collection = tungsten.Collection.extend({
+    initDebug: _.noop,
+    tutorialObj: true
+  });
+  var ComponentWidget = tungsten.ComponentWidget;
 
   helpers.initMustacheCode(CodeMirror);
 

--- a/gh_pages/js/tutorials_app.js
+++ b/gh_pages/js/tutorials_app.js
@@ -1,16 +1,52 @@
 (function(CodeMirror, _, tungsten, helpers) {
   'use strict';
-  var tungstenEnv = helpers.initTungsten(tungsten, _);
-  var runtimeObjects = tungstenEnv.runtimeObjects;
-  var View = tungstenEnv.View;
-  var Model = tungstenEnv.Model;
-  var Collection = tungstenEnv.Collection;
-  var ComponentWidget = tungstenEnv.ComponentWidget;
+  tungsten.plugins.event.all.forEach(tungsten.addEventPlugin);
+  var runtimeObjects = [];
+  tungsten.View.prototype._initialize = tungsten.View.prototype.initialize;
+  tungsten.View.prototype.initialize = function(opts) {
+    if (!opts.parentView && !this.tutorialObj) {
+      runtimeObjects.push(this);
+    }
+    this._initialize(opts);
+  };
+  tungsten.Model.prototype._initialize = tungsten.Model.prototype.initialize;
+  tungsten.Model.prototype.initialize = function(attributes, opts) {
+    opts = opts || {};
+    if (!this.tutorialObj) {
+      runtimeObjects.push(this);
+    }
+    this._initialize(opts);
+  };
+  tungsten.Collection.prototype._initialize = tungsten.Collection.prototype.initialize;
+  tungsten.Collection.prototype.initialize = function(models, opts) {
+    opts = opts || {};
+    if (!this.tutorialObj) {
+      runtimeObjects.push(this);
+    }
+    this._initialize(opts);
+  };
+
+  var View = tungsten.View.extend({
+    initDebug: _.noop,
+    _setElement: tungsten.Backbone.View.prototype._setElement,
+    tutorialObj: true
+  });
+  var Model = tungsten.Model.extend({
+    initDebug: _.noop,
+    tutorialObj: true
+  });
+  var Collection = tungsten.Collection.extend({
+    initDebug: _.noop,
+    tutorialObj: true
+  });
+  var ComponentWidget = tungsten.ComponentWidget;
 
   // Code Mirror Extensions and options
   helpers.initMustacheCode(CodeMirror);
 
   var codeOptions = helpers.codeOptions;
+
+
 
   // Views and Template
   var rawTemplates = {
@@ -149,6 +185,9 @@
       // Destroy any views that were created in the last run to ensure a fresh runtime
       _.invoke(runtimeObjects, 'stopListening');
       _.invoke(runtimeObjects, 'destroy');
+      _.each(runtimeObjects, function(item, index) {
+        runtimeObjects[index] = null;
+      });
       runtimeObjects = [];
       document.getElementById('app').innerHTML = '';
       try {


### PR DESCRIPTION
Turns out sharing the tungsten environment code as a global causes more problems than it was worth. This fixes an issue where a new tungsten view was created each time you ran your tutorial/sandbox app.
