### PR TITLE
Fix drag and drop example for ghpages build

### DIFF
--- a/examples/drag-and-drop/index.html
+++ b/examples/drag-and-drop/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Tungsten.js • DnD</title>
-  <link rel="stylesheet" href="node_modules/dragula/dist/dragula.min.css"/>
+  <link rel="stylesheet" href="node_modules/dragula/dist/dragula.min.css">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>


### PR DESCRIPTION
# Overview

Drag and drop example wasn't working properly in the ghpages build.  Turns out it was because the dragula css wasn't being included in the build due to a regexp issue with the `link` tag in the example html.  Fixed.