### PR TITLE
Remove lambda with content example from ghpages

### DIFF
--- a/gh_pages/config.json
+++ b/gh_pages/config.json
@@ -15,7 +15,6 @@
   "examples": {
     "DBMonster": "dbmonster-component",
     "Drag & Drop": "drag-and-drop",
-    "Lambdas with Content": "lambda-content",
     "SVG": "svg",
     "TodoMVC": "todomvc"
   },


### PR DESCRIPTION
# Overview

The lambda with content example is useful in the repo for testing and demo'ing, but without context in the ghpages it's a bit confusing.  This removes it from that build.