### PR TITLE
Adding exception if a tag is being closed before its open tag is complete

### DIFF
--- a/src/template/compiler/stack.js
+++ b/src/template/compiler/stack.js
@@ -215,6 +215,12 @@ templateStack.processObject = function(obj) {
 templateStack._closeElem = function(obj) {
   let i;
 
+  if (obj.isOpen) {
+    logger.exception('Tag is closed before open tag is completed. Check for unpaired quotes.');
+    // Close the element off to avoid other errors
+    obj.close();
+  }
+
   if (obj.children && obj.children.length) {
     // Process child nodes
     let children = [];


### PR DESCRIPTION
# Overview

Templates where open tags were being closed by hitting the end of the file, not by a completed tag were throwing a cryptic error message. This adds an explicit one.

## Details

Templates with missing quotes, such as 
```
<p class="foo>contents</p>
```
were being parsed as 
```
{
  tag: 'p'
  attributes: {
     'class': 'foo>contents</p>'
  }
}
```
and then being closed by the parser hitting the end of the file. The error message was the unhelpful: "Uncaught TypeError: Cannot read property 'length' of undefined".

This change throws an explicit exception, and corrects the issue to avoid further internal errors.