### PR TITLE
Fix for IE scroll data

### DIFF
--- a/src/event/handlers/window_events.js
+++ b/src/event/handlers/window_events.js
@@ -4,6 +4,7 @@
 'use strict';
 
 var window = require('global/window');
+var document = require('global/document');
 var eventsCore = require('../events_core');
 var eventWrapper = require('../tungsten_event');
 
@@ -12,9 +13,10 @@ var eventWrapper = require('../tungsten_event');
  * @return {Object}       Scroll properties of element
  */
 var getScrollData = function() {
+  var doc = document.documentElement;
   return {
-    x: window.scrollX,
-    y: window.scrollY
+    x: (window.pageXOffset || doc.scrollLeft) - (doc.clientLeft || 0),
+    y: (window.pageYOffset || doc.scrollTop)  - (doc.clientTop || 0)
   };
 };
 


### PR DESCRIPTION
# Overview

The scroll data that was passed in via the event object for `win-scroll` events was broken for IE.
This uses the functionality from [jQuery 1.9.1](https://github.com/jquery/jquery/blob/055cb7534e2dcf7ee8ad145be83cb2d74b5331c7/test/data/jquery-1.9.1.js#L9680), which should support the browsers we want
## Details

If appropriate..
- Tested the snippets in console for Chrome, Firefox and IE (emulation for Edge, 10, and 8) and the values returned seemed in line with scroll positions
