### PR TITLE
Collapsible pages nav

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ test/testbuild.prod.js
 test/coverage/
 examples/**/*.js.map
 examples/**/*.min.js
+examples/**/bower_components/*
 .DS_Store
 output/
 npm-debug.log

--- a/examples/web-components/index.html
+++ b/examples/web-components/index.html
@@ -7,15 +7,15 @@
         window.Polymer = window.Polymer || {};
         window.Polymer.dom = 'shadow';
     </script>
-    <link rel="import" href="vendor/google-map/google-map.html"/>
-    <link rel="import" href="vendor/paper-input/paper-input.html">
-    <link rel="import" href="vendor/paper-drawer-panel/paper-drawer-panel.html"/>
-    <link rel="import" href="vendor/paper-item/paper-item.html"/>
-    <link rel="import" href="vendor/paper-toolbar/paper-toolbar.html"/>
-    <link rel="import" href="vendor/iron-icon/iron-icon.html"/>
-    <link rel="import" href="vendor/iron-icons/iron-icons.html"/>
-    <link rel="import" href="vendor/paper-header-panel/paper-header-panel.html"/>
-    <link rel="import" href="vendor/iron-selector/iron-selector.html"/>
+    <link rel="import" href="bower_components/google-map/google-map.html"/>
+    <link rel="import" href="bower_components/paper-input/paper-input.html">
+    <link rel="import" href="bower_components/paper-drawer-panel/paper-drawer-panel.html"/>
+    <link rel="import" href="bower_components/paper-item/paper-item.html"/>
+    <link rel="import" href="bower_components/paper-toolbar/paper-toolbar.html"/>
+    <link rel="import" href="bower_components/iron-icon/iron-icon.html"/>
+    <link rel="import" href="bower_components/iron-icons/iron-icons.html"/>
+    <link rel="import" href="bower_components/paper-header-panel/paper-header-panel.html"/>
+    <link rel="import" href="bower_components/iron-selector/iron-selector.html"/>
     <style>
         body {
             font-family: Arial;

--- a/gh_pages/config.json
+++ b/gh_pages/config.json
@@ -55,9 +55,11 @@
       "./css/app.css"
     ],
     "js/all.js": [
+      "./js/app.js",
       "./node_modules/underscore/underscore-min.js"
     ],
     "js/sandbox.js": [
+      "./js/app.js",
       "./node_modules/underscore/underscore-min.js",
       "../dist/tungsten.backbone.debug.web.js",
       "../dist/tungsten.event.all.js",
@@ -78,6 +80,7 @@
       "./js/sandbox_app.js"
     ],
     "js/tutorials.js": [
+      "./js/app.js",
       "./node_modules/underscore/underscore-min.js",
       "../dist/tungsten.backbone.debug.web.js",
       "../dist/tungsten.event.all.js",
@@ -106,3 +109,4 @@
     ]
   }
 }
+

--- a/gh_pages/css/side-menu.css
+++ b/gh_pages/css/side-menu.css
@@ -34,15 +34,6 @@ This is the parent `<div>` that contains the menu and the content area.
   padding-left: 0;
 }
 
-#layout.active #menu {
-  left: 150px;
-  width: 150px;
-}
-
-#layout.active .menu-link {
-  left: 150px;
-}
-
 /*
 The content `<div>` is where all your content goes.
 */
@@ -221,17 +212,40 @@ Hides the menu at `48em`, but modify this based on your app's needs.
   display: none;
 }
 
-#layout.active .menu-link {
-  left: 225px;
+.menu_toggle {
+  float: right;
+  width: 50px;
+  text-align: center;
+  height: 37px;
+  display: inline-block;
+  line-height: 37px;
+  margin-top: -0.6em;
 }
 
-/* Only apply this when the window is small. Otherwise, the following
-case results in extra padding on the left:
-    * Make the window small.
-    * Tap the menu to trigger the active state.
-    * Make the window large again.
-*/
+.menu_toggle:after {
+  display: inline-block;
+  /* \0000AB = &laquo; */
+  content: '\0000AB';
+}
+
 #layout.active {
-  position: relative;
-  left: 150px;
+  padding-left: 0;
+}
+
+#layout.active .menu_toggle {
+  width: 25px;
+}
+
+#layout.active .menu_toggle:after {
+  /* \0000BB = &raquo; */
+  content: '\0000BB';
+}
+
+#layout.active #menu {
+  left: 25px;
+  background: transparent;
+}
+
+#layout.active .pure-menu-list {
+  left: -25px;
 }

--- a/gh_pages/js/app.js
+++ b/gh_pages/js/app.js
@@ -1,0 +1,27 @@
+(function() {
+  /* eslint-env browser */
+  var toggle = document.getElementById('menu-toggle');
+  if (!document.addEventListener) {
+    // if we're not at least in IE8, just hide the toggle
+    toggle.style.display = 'none';
+    return;
+  }
+  var layout = document.getElementById('layout');
+
+  toggle.addEventListener('click', function toggleMenu(e) {
+    // Checking the left position of the click rather than listening on a specific element due to styling on the element
+    var minX, maxX;
+    if (layout.classList.contains('active')) {
+      // collapsed
+      minX = 0;
+      maxX = 25;
+    } else {
+      minX = 175;
+      maxX = 225;
+    }
+    if (e.clientX >= minX && e.clientX <= maxX) {
+      e.preventDefault();
+      layout.classList.toggle('active');
+    }
+  });
+})();

--- a/gh_pages/templates/layout.mustache
+++ b/gh_pages/templates/layout.mustache
@@ -10,7 +10,7 @@
     <div id="layout">
       <div id="menu">
         <div class="pure-menu">
-          <a class="pure-menu-heading" href="index.html">Tungsten.js</a>
+          <a class="pure-menu-heading" href="index.html" id="menu-toggle">Tungsten.js<span class="menu_toggle">&nbsp;</span></a>
           <ul class="pure-menu-list top-menu">
             <li><a href="index.html" class="pure-menu-link pure-menu-section">Docs</a>
               <ul class="pure-menu-list"> {{#docs}} <li class="pure-menu-item"><a href="{{url_name}}" class="pure-menu-link">{{name}}</a></li> {{/docs}} </ul>


### PR DESCRIPTION
# Overview

Allows the left nav on Github pages to be collapsed, to allow extra screen room for workshops using it

The web-components example didn't seem to be building so changes were made to get that working, but can be rolled back if unneeded