### PR TITLE
abstract error messages to one file, with an extension method

### DIFF
--- a/adaptors/backbone/backbone_view_widget.js
+++ b/adaptors/backbone/backbone_view_widget.js
@@ -12,6 +12,7 @@
 'use strict';
 
 var logger = require('../../src/utils/logger');
+var errors = require('../../src/utils/errors');
 
 /**
  * Wrapper Widget for child views
@@ -46,7 +47,7 @@ function BackboneViewWidget(template, childView, context, parentView) {
       // Any other value is treated as a parent model lookup
       this.model = parentView.model.getDeep(scope);
     } else {
-      logger.warn('ChildView was passed as object without a scope property');
+      logger.warn(errors.childViewWasPassedAsObjectWithoutAScopeProperty());
     }
   }
 }

--- a/adaptors/backbone/base_collection.js
+++ b/adaptors/backbone/base_collection.js
@@ -7,6 +7,7 @@ var _ = require('underscore');
 var Backbone = require('backbone');
 var tungsten = require('../../src/tungsten');
 var logger = require('../../src/utils/logger');
+var errors = require('../../src/utils/errors');
 
 var eventTrigger = require('./event_trigger');
 var ComponentWidget = require('./component_widget');
@@ -106,12 +107,12 @@ var BaseCollection = Backbone.Collection.extend({
 
       for (let i = 0; i < methods.length; i++) {
         if (protoProps[methods[i]]) {
-          var msg = 'Collection.' + methods[i] + ' may not be overridden';
           if (staticProps && staticProps.debugName) {
-            msg += ' for collection "' + staticProps.debugName + '"';
+            logger.warn(errors.collectionMethodMayNotBeOverridden(methods[i], staticProps.debugName));
+          } else {
+            logger.warn(errors.collectionMethodMayNotBeOverridden(methods[i]));
           }
-          logger.warn(msg);
-        // Replace attempted override with base version
+          // Replace attempted override with base version
           protoProps[methods[i]] = wrapOverride(BaseCollection.prototype[methods[i]], protoProps[methods[i]]);
         }
       }
@@ -247,7 +248,7 @@ BaseCollection.prototype.reset = function(models, options = {}) {
         }
       }
       if (!allObjects || !_.isArray(this.initialData)) {
-        logger.warn('Collection expected array of objects but got: ' + initialStr);
+        logger.warn(errors.collectionExpectedArrayOfObjectsButGot(initialStr));
       }
     }
   }

--- a/adaptors/backbone/base_model.js
+++ b/adaptors/backbone/base_model.js
@@ -6,6 +6,7 @@ var _ = require('underscore');
 var Backbone = require('backbone');
 var tungsten = require('../../src/tungsten');
 var logger = require('../../src/utils/logger');
+var errors = require('../../src/utils/errors');
 var ComponentWidget = require('./component_widget');
 var eventTrigger = require('./event_trigger');
 /**
@@ -65,12 +66,12 @@ var BaseModel = Backbone.Model.extend({
 
       for (let i = 0; i < methods.length; i++) {
         if (protoProps[methods[i]]) {
-          var msg = 'Model.' + methods[i] + ' may not be overridden';
           if (staticProps && staticProps.debugName) {
-            msg += ' for model "' + staticProps.debugName + '"';
+            logger.warn(errors.modelMethodMayNotBeOverridden(methods[i], staticProps.debugName));
+          } else {
+            logger.warn(errors.modelMethodMayNotBeOverridden(methods[i]));
           }
-          logger.warn(msg);
-        // Replace attempted override with base version
+          // Replace attempted override with base version
           protoProps[methods[i]] = wrapOverride(BaseModel.prototype[methods[i]], protoProps[methods[i]]);
         }
       }
@@ -563,7 +564,7 @@ BaseModel.prototype.set = function(key, val, options) {
       delete options.initialData;
       this.initialData = JSON.parse(initialStr || '{}');
       if (!_.isObject(this.initialData) || _.isArray(this.initialData)) {
-        logger.warn('Model expected object of attributes but got: ' + initialStr);
+        logger.warn(errors.modelExpectedObjectOfAttributesButGot(initialStr));
       }
     }
 

--- a/adaptors/backbone/base_view.js
+++ b/adaptors/backbone/base_view.js
@@ -8,6 +8,7 @@ var _ = require('underscore');
 var Backbone = require('backbone');
 var tungsten = require('../../src/tungsten');
 var logger = require('../../src/utils/logger');
+var errors = require('../../src/utils/errors');
 var ViewWidget = require('./backbone_view_widget');
 var ComponentWidget = require('./component_widget');
 
@@ -181,7 +182,7 @@ var BaseView = Backbone.View.extend({
       // Compare full template against full DOM
       var diff = this.getTemplateDiff();
       if (diff.indexOf('<ins>') + diff.indexOf('<del>') > -2) {
-        logger.warn('DOM does not match VDOM for view "' + this.getDebugName() + '". Use debug panel to see differences');
+        logger.warn(errors.domDoesNotMatchVDOMForView(this.getDebugName()));
       }
     }
   },
@@ -419,11 +420,11 @@ var BaseView = Backbone.View.extend({
 
       for (var i = 0; i < methods.length; i++) {
         if (protoProps[methods[i]]) {
-          var msg = 'View.' + methods[i] + ' may not be overridden';
           if (staticProps && staticProps.debugName) {
-            msg += ' for view "' + staticProps.debugName + '"';
+            logger.warn(errors.viewMethodMayNotBeOverridden(methods[i], staticProps.debugName));
+          } else {
+            logger.warn(errors.viewMethodMayNotBeOverridden(methods[i]));
           }
-          logger.warn(msg);
           // Replace attempted override with base version
           protoProps[methods[i]] = wrapOverride(BaseView.prototype[methods[i]], protoProps[methods[i]]);
         }

--- a/adaptors/backbone/component_widget.js
+++ b/adaptors/backbone/component_widget.js
@@ -2,13 +2,14 @@
 
 var _ = require('underscore');
 var logger = require('../../src/utils/logger');
+var errors = require('../../src/utils/errors');
 
 var modelFunctionsToMap = ['trigger', 'set', 'get', 'has', 'doSerialize', 'save', 'fetch', 'sync', 'validate', 'isValid'];
 var modelFunctionsToDummy = ['on', 'off', 'listenTo'];
 
 var getDummyFunction = function(fn) {
   return function() {
-    logger.warn('Component.' + fn + ' may not be called directly.');
+    logger.warn(errors.componentFunctionMayNotBeCalledDirectly(fn));
   };
 };
 
@@ -56,7 +57,7 @@ function ComponentWidget(ViewConstructor, model, template, options, key) {
       if (typeof this[fn] === 'undefined') {
         this[fn] = _.bind(model[fn], model);
       } else {
-        logger.warn('Cannot overwrite component method: ' + fn);
+        logger.warn(errors.cannotOverwriteComponentMethod(fn));
       }
     }
   }

--- a/src/debug/panel_js/model_panel_events.js
+++ b/src/debug/panel_js/model_panel_events.js
@@ -3,6 +3,7 @@
 var window = require('global/window');
 var _ = require('underscore');
 var logger = require('../../utils/logger');
+var errors = require('../../utils/errors');
 var utils = require('./utils');
 var appData = require('./app_data');
 
@@ -81,9 +82,7 @@ module.exports = function() {
       appData.selectedModel.obj.set(key, value);
       appData.updateSelectedModel();
     } catch (ex) {
-      var message = 'Unable to parse "' + e.currentTarget.value + '" to a valid value. Input must match JSON format';
-      utils.alert(message);
-      logger.warn(message);
+      utils.alert(errors.unableToParseToAValidValueMustMatchJSONFormat(e.currentTarget.value));
       utils.selectElements('js-model-property-value')[0].focus();
     }
   });

--- a/src/debug/vtree_to_string.js
+++ b/src/debug/vtree_to_string.js
@@ -7,6 +7,7 @@
 
 var _ = require('underscore');
 var logger = require('../utils/logger');
+var errors = require('../utils/errors');
 var syntaxHighlight = require('./syntax_highlight');
 
 var virtualDomImplementation = require('../vdom/virtual_dom_implementation');
@@ -54,7 +55,7 @@ function toString(vtree, escaped) {
     if (typeof vtree.templateToString === 'function') {
       output += vtree.templateToString(toString);
     } else {
-      logger.warn('Widget type: ' + vtree.constructor.name + ' has no templateToString function, falling back to DOM');
+      logger.warn(errors.widgetTypeHasNoTemplateToStringFunctionFallingBackToDOM(vtree.constructor.name));
       var elem = vdom.create(virtualHyperscript('div', {}, vtree));
       output += elem.innerHTML;
     }

--- a/src/debug/window_manager.js
+++ b/src/debug/window_manager.js
@@ -6,6 +6,7 @@ var _ = require('underscore');
 var utils = require('./panel_js/utils');
 var appData = require('./panel_js/app_data');
 var logger = require('../utils/logger');
+var errors = require('../utils/errors');
 var highlighter = require('./highlighter');
 
 var isNode = require('./is_node');
@@ -26,7 +27,7 @@ function getWindow() {
   // Launch panel
   debugWindow = window.open('', 'TungstenDebugger', 'directories=no,titlebar=no,toolbar=no,location=no,status=no,menubar=no,width=800,height=640');
   if (!debugWindow) {
-    logger.error('Unable to launch debug panel. You may need to allow the popup or run "window.launchDebugger()" from your console');
+    logger.error(errors.unableToLaunchDebugPanel());
   } else {
     debugWindow.document.title = 'DEBUG: ' + window.document.title;
     debugWindow.onerror = collectError;

--- a/src/event/events_core.js
+++ b/src/event/events_core.js
@@ -4,6 +4,7 @@ var dataset = require('data-set');
 var eventWrapper = require('./tungsten_event');
 var _ = require('underscore');
 var logger = require('../utils/logger');
+var errors = require('../utils/errors');
 
 module.exports = {};
 
@@ -136,10 +137,10 @@ module.exports.removeEvent = function(evt) {
     } else if (evt.length === 4) {
       removeElementEvents(evt[0], evt[1], evt[2], evt[3]);
     } else {
-      logger.warn('Object does not meet expected event spec', evt);
+      logger.warn(errors.objectDoesNotMeetExpectedEventSpec(), evt);
     }
   } else {
-    logger.warn('Object does not meet expected event spec', evt);
+    logger.warn(errors.objectDoesNotMeetExpectedEventSpec(), evt);
   }
 };
 

--- a/src/template/adaptor.js
+++ b/src/template/adaptor.js
@@ -4,6 +4,7 @@ var _ = require('underscore');
 var ToString = require('./stacks/string');
 var Context = require('./template_context');
 var logger = require('./../utils/logger');
+var errors = require('./../utils/errors');
 var types = require('./types');
 var virtualDomImplementation = require('../vdom/virtual_dom_implementation');
 var isWidget = virtualDomImplementation.isWidget;
@@ -161,7 +162,7 @@ function render(stack, template, context, partials, parentView) {
         }
       } else {
         // @TODO, perhaps return this string as the partial result so it renders to the page?
-        logger.warn('Warning: no partial registered with the name ' + partialName);
+        logger.warn(errors.warningNoPartialRegisteredWithTheName(partialName));
       }
       break;
 
@@ -346,7 +347,7 @@ var attachView = function(view, template, createWidget, partials, childClasses) 
   if (template.t === types.PARTIAL) {
     var partialName = template.r;
     if (!partials[partialName]) {
-      logger.warn('Warning: no partial registered with the name ' + partialName);
+      logger.warn(errors.warningNoPartialRegisteredWithTheName(partialName));
       return null;
     } else {
       var partialTemplate = partials[partialName];

--- a/src/template/compiler/index.js
+++ b/src/template/compiler/index.js
@@ -5,6 +5,7 @@ const _ = require('underscore');
 const parser = require('./parser');
 const stack = require('./stack');
 const logger = require('./compiler_logger');
+const errors = require('../../utils/errors');
 const processTemplate = require('./languages/mustache');
 
 /**
@@ -43,7 +44,7 @@ function getTemplate(template, options) {
   let output = {};
 
   if (stack.stack.length > 0) {
-    logger.exception('Not all tags were closed properly', stack.stack);
+    logger.exception(errors.notAllTagsWereClosedProperly(), stack.stack);
   }
 
   parser.end();

--- a/src/template/compiler/parser.js
+++ b/src/template/compiler/parser.js
@@ -4,6 +4,7 @@ const Parser = require('htmlparser2/lib/Parser');
 const types = require('../types');
 const stack = require('./stack');
 const logger = require('./compiler_logger');
+const errors = require('../../utils/errors');
 const decoder = require('./decoder');
 
 // Taken from https://github.com/fb55/htmlparser2/blob/master/lib/Parser.js#L59
@@ -147,7 +148,7 @@ MustacheParser.prototype.onclosetag = function(name) {
   }
 
   if (name in voidElements) {
-    logger.warn(name + ' is a void element so does not need a closing tag');
+    logger.warn(errors.elementIsAVoidElementSoDoesNotNeedAClosingTag(name));
     return;
   }
 
@@ -160,10 +161,10 @@ MustacheParser.prototype.onclosetag = function(name) {
       }
     } else {
       let current = this._stack[this._stack.length - 1];
-      logger.exception('</' + name + '> where a </' + current + '> should be.');
+      logger.exception(errors.wrongClosingElementType(name, current));
     }
   } else {
-    logger.exception('</' + name + '> with no paired <' + name + '>');
+    logger.exception(errors.closingHTMLElementWithNoPair(name));
   }
 };
 

--- a/src/template/compiler/stack.js
+++ b/src/template/compiler/stack.js
@@ -4,6 +4,7 @@ const _ = require('underscore');
 const types = require('../types');
 const htmlHelpers = require('../html_helpers');
 const logger = require('./compiler_logger');
+const errors = require('../../utils/errors');
 
 // Keys to use for the outputted array
 const templateKeys = {
@@ -104,7 +105,7 @@ templateStack.openElement = function(type, value) {
     if (prev && this.htmlValidationMode) {
       let isValid = htmlHelpers.validation.isValidChild(prev, value, this.htmlValidationMode === 'strict');
       if (isValid !== true) {
-        logger.warn('Cannot place this ' + value + ' tag within a ' + prev.tagName + ' tag. ' + isValid);
+        logger.warn(errors.cannotPlaceThisTagWithinAPreviousTag(value, prev.tagName, isValid));
       }
     }
     elem.childTags = {};
@@ -216,7 +217,7 @@ templateStack._closeElem = function(obj) {
   let i;
 
   if (obj.isOpen) {
-    logger.exception('Tag is closed before open tag is completed. Check for unpaired quotes.');
+    logger.exception(errors.tagIsClosedBeforeOpenTagIsCompletedCheckForUnpairedQuotes());
     // Close the element off to avoid other errors
     obj.close();
   }
@@ -308,7 +309,7 @@ templateStack.closeElement = function(closingElem) {
       } else {
         actualTag = '{{/' + closingElem.value + '}}';
       }
-      logger.exception(actualTag + ' where a ' + expectedTag + ' should be.');
+      logger.exception(errors.differentTagThanExpected(actualTag, expectedTag));
     } else {
       // If they match, everything lines up
       this._closeElem(this.stack.pop());
@@ -316,9 +317,9 @@ templateStack.closeElement = function(closingElem) {
   } else {
     if (closingElem.tagName) {
       // Something has gone terribly wrong
-      logger.exception('</' + closingElem.tagName + '> with no paired <' + closingElem.tagName + '>');
+      logger.exception(errors.closingHTMLElementWithNoPair(closingElem.tagName));
     } else {
-      logger.exception('{{/' + closingElem.value + '}} with no paired {{#' + closingElem.value + '}}');
+      logger.exception(errors.closingMustacheElementWithNoPair(closingElem.value));
     }
   }
 };
@@ -326,7 +327,7 @@ templateStack.closeElement = function(closingElem) {
 templateStack.getOutput = function() {
   // If any items are left on the stack, they weren't closed by the template
   if (this.stack.length) {
-    logger.warn('Template contains unclosed items', this.stack);
+    logger.warn(errors.templateContainsUnclosedItems(), this.stack);
   }
   // Always return the array
   return this.result;
@@ -387,7 +388,7 @@ function processAttributeArray(attrArray) {
       // Ensure there are no tokens in a non-dynamic attribute name
       for (let j = 0; j < name.length; j++) {
         if (typeof name[j] !== 'string') {
-          logger.warn('Mustache token cannot be in attribute names', name[j]);
+          logger.warn(errors.mustacheTokenCannotBeInAttributeNames(), name[j]);
         }
       }
 
@@ -416,7 +417,7 @@ function processAttributeArray(attrArray) {
     } else if (pushingTo === name) {
       if (name.length === 0) {
         if (item.type === types.INTERPOLATOR) {
-          logger.warn('Double curly interpolators cannot be in attributes', item.value);
+          logger.warn(errors.doubleCurlyInterpolatorsCannotBeInAttributes(), item.value);
         } else if (item.type === types.SECTION) {
           attrs.dynamic.push(templateStack.processObject(item));
           continue;

--- a/src/template/stacks/default.js
+++ b/src/template/stacks/default.js
@@ -3,6 +3,7 @@
 var document = require('global/document');
 var processProperties = require('../process_properties');
 var logger = require('../../utils/logger');
+var errors = require('../../utils/errors');
 
 // IE8 and back don't create whitespace-only nodes from the DOM
 // This sets a flag so that templates don't create them either
@@ -154,7 +155,7 @@ DefaultStack.prototype.closeElement = function(closingElem) {
   if (openElem) {
     var openID = openElem.id;
     if (openID !== id) {
-      logger.warn(tagName + ' tags improperly paired, closing ' + openID + ' with close tag from ' + id);
+      logger.warn(errors.tagsImproperlyPairedClosing(tagName, openID, id));
       do {
         openElem = this.stack.pop();
         this._closeElem(openElem);
@@ -169,7 +170,7 @@ DefaultStack.prototype.closeElement = function(closingElem) {
     this.closeElement(this.openElement('p', {}));
   } else {
     // Something has gone terribly wrong
-    logger.warn('Closing element ' + id + ' when the stack was empty');
+    logger.warn(errors.closingElementWhenTheStackWasEmpty(id));
   }
 };
 

--- a/src/template/template_context.js
+++ b/src/template/template_context.js
@@ -10,6 +10,7 @@
 
 var _ = require('underscore');
 var logger = require('../utils/logger');
+var errors = require('../utils/errors');
 
 /** @type {Object} storage to prevent repeated warnings about the same computed property */
 var computedPropertyWarnings = {};
@@ -207,7 +208,7 @@ Context.prototype.lookup = function(name, handleLambda) {
           } else {
             if (computedPropertyWarnings[name] !== true) {
               computedPropertyWarnings[name] = true;
-              logger.warn('Computed properties are now deprecated and will be removed soon. Please change "' + name + '" to a derived property');
+              logger.warn(errors.computedPropertiesAreNowDeprecatedPleaseChange(name));
             }
             value = value.call(fnContext);
           }

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -1,0 +1,63 @@
+/**
+ * Container for generic error messages that can be extended based on needs
+ *
+ * @author    Henry Morgan <hemorgan@wayfair.com>
+ */
+'use strict';
+
+const logger = require('./logger');
+
+/**
+ * Extends a generic error message with custom information, i.e. implementation-specific hints
+ * @param  {string} error The name of the error function to extend
+ * @param  {string} customMsg The custom message to append to the generic error message.
+ */
+function extend(error, customMsg) {
+  if (!this.hasOwnProperty(error)) {
+    logger.warn(`Tried to extend a nonexistent error message: ${error}`);
+    return;
+  }
+  let origError = this[error];
+  this[error] = function() {
+    return `${origError.apply(origError, arguments)}. ${customMsg}`;
+  };
+}
+
+module.exports = {
+  extend: extend,
+
+  childViewWasPassedAsObjectWithoutAScopeProperty: () => 'ChildView was passed as object without a scope property',
+  collectionMethodMayNotBeOverridden: function(methodName, debugName = null) {
+    return `Collection.${methodName} may not be overridden` + (debugName ? ` for collection "${debugName}"` : '');
+  },
+  collectionExpectedArrayOfObjectsButGot: (initialStr) => `Collection expected array of objects but got: ${initialStr}`,
+  modelMethodMayNotBeOverridden: function(methodName, debugName = null) {
+    return `Model.${methodName} may not be overridden` + (debugName ? ` for model "${debugName}"` : '');
+  },
+  modelExpectedObjectOfAttributesButGot: (initialStr) => `Model expected object of attributes but got: ${initialStr}`,
+  domDoesNotMatchVDOMForView: (debugName) => `DOM does not match VDOM for view "${debugName}". Use debug panel to see differences`,
+  viewMethodMayNotBeOverridden: function(methodName, debugName = null) {
+    return `View.${methodName} may not be overridden` + (debugName ? ` for view "${debugName}"` : '');
+  },
+  componentFunctionMayNotBeCalledDirectly: (fn) => `Component.${fn} may not be called directly`,
+  cannotOverwriteComponentMethod: (fn) => `Cannot overwrite component method: ${fn}`,
+  unableToParseToAValidValueMustMatchJSONFormat: (value) => `Unable to parse "${value}" to a valid value. Input must match JSON format`,
+  widgetTypeHasNoTemplateToStringFunctionFallingBackToDOM: (name) => `Widget type: ${name} has no templateToString function, falling back to DOM`,
+  unableToLaunchDebugPanel: () => 'Unable to launch debug panel. You may need to allow the popup or run "window.launchDebugger()" from your console',
+  objectDoesNotMeetExpectedEventSpec: () => 'Object does not meet expected event spec',
+  warningNoPartialRegisteredWithTheName: (partialName) => `Warning: no partial registered with the name ${partialName}`,
+  notAllTagsWereClosedProperly: () => 'Not all tags were closed properly',
+  elementIsAVoidElementSoDoesNotNeedAClosingTag: (name) => `${name} is a void element so does not need a closing tag`,
+  wrongClosingElementType: (name, current) => `</${name}> where a </${current}> should be`,
+  cannotPlaceThisTagWithinAPreviousTag: (value, prevTagName, isValid) => `Cannot place this ${value} tag within a ${prevTagName} tag. ${isValid}`,
+  tagIsClosedBeforeOpenTagIsCompletedCheckForUnpairedQuotes: () => 'Tag is closed before open tag is completed. Check for unpaired quotes',
+  differentTagThanExpected: (actualTag, expectedTag) => `${actualTag} where a ${expectedTag} should be`,
+  closingHTMLElementWithNoPair: (closingElemTagName) => `</${closingElemTagName}> with no paired <${closingElemTagName}>`,
+  closingMustacheElementWithNoPair: (closingElemValue) => `{{/${closingElemValue}}} with no paired {{#${closingElemValue}}}`,
+  templateContainsUnclosedItems: () => 'Template contains unclosed items',
+  mustacheTokenCannotBeInAttributeNames: () => 'Mustache token cannot be in attribute names',
+  doubleCurlyInterpolatorsCannotBeInAttributes: () => 'Double curly interpolators cannot be in attributes',
+  tagsImproperlyPairedClosing: (tagName, openID, id) => `${tagName} tags improperly paired, closing ${openID} with close tag from ${id}`,
+  closingElementWhenTheStackWasEmpty: (id) => `Closing element ${id} when the stack was empty`,
+  computedPropertiesAreNowDeprecatedPleaseChange: (name) => `Computed properties are now deprecated and will be removed soon. Please change "${name}" to a derived property`
+};

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -27,16 +27,16 @@ module.exports = {
   extend: extend,
 
   childViewWasPassedAsObjectWithoutAScopeProperty: () => 'ChildView was passed as object without a scope property',
-  collectionMethodMayNotBeOverridden: function(methodName, debugName = null) {
+  collectionMethodMayNotBeOverridden: function(methodName, debugName) {
     return `Collection.${methodName} may not be overridden` + (debugName ? ` for collection "${debugName}"` : '');
   },
   collectionExpectedArrayOfObjectsButGot: (initialStr) => `Collection expected array of objects but got: ${initialStr}`,
-  modelMethodMayNotBeOverridden: function(methodName, debugName = null) {
+  modelMethodMayNotBeOverridden: function(methodName, debugName) {
     return `Model.${methodName} may not be overridden` + (debugName ? ` for model "${debugName}"` : '');
   },
   modelExpectedObjectOfAttributesButGot: (initialStr) => `Model expected object of attributes but got: ${initialStr}`,
   domDoesNotMatchVDOMForView: (debugName) => `DOM does not match VDOM for view "${debugName}". Use debug panel to see differences`,
-  viewMethodMayNotBeOverridden: function(methodName, debugName = null) {
+  viewMethodMayNotBeOverridden: function(methodName, debugName) {
     return `View.${methodName} may not be overridden` + (debugName ? ` for view "${debugName}"` : '');
   },
   componentFunctionMayNotBeCalledDirectly: (fn) => `Component.${fn} may not be called directly`,

--- a/test/src/utils/errors_spec.js
+++ b/test/src/utils/errors_spec.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const errors = require('../../../src/utils/errors');
+const logger = require('../../../src/utils/logger');
+
+describe('errors.js public API', function() {
+  describe('errors.extend', function() {
+    it('should be a function', function() {
+      expect(errors.extend).to.be.a('function');
+    });
+
+    const customHint = 'Check that all model variables are defined in your PHP view';
+    const originalMessage = errors.domDoesNotMatchVDOMForView('ArbitraryView01');
+    it('should extend an error message appropriately', function() {
+      errors.extend('domDoesNotMatchVDOMForView', customHint);
+      jasmineExpect(errors.domDoesNotMatchVDOMForView('ArbitraryView01')).toEqual(`${originalMessage}. ${customHint}`);
+    });
+    it('should support multiple extensions of an error message', function() {
+      const customHint2 = 'This includes derived properties!';
+      errors.extend('domDoesNotMatchVDOMForView', customHint2);
+      jasmineExpect(errors.domDoesNotMatchVDOMForView('ArbitraryView01')).toEqual(`${originalMessage}. ${customHint}. ${customHint2}`);
+    });
+    it('should reject nonexistent error messages', function() {
+      const nonexistentError = 'DOMdoesntmatch__~~~theVDOM~~~__forview';
+      spyOn(logger, 'warn');
+      errors.extend(nonexistentError, customHint);
+      jasmineExpect(logger.warn).toHaveBeenCalledWith(`Tried to extend a nonexistent error message: ${nonexistentError}`);
+    });
+  });
+});


### PR DESCRIPTION
# Overview

Abstracts error messages to a single file. Core motivation: Allowing extension of the generic error messages with custom/implementation-specific info and hints.

