### PR TITLE
Refactor tungsten errors module

### DIFF
--- a/adaptors/backbone/backbone_view_widget.js
+++ b/adaptors/backbone/backbone_view_widget.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-var logger = require('../../src/utils/logger');
 var errors = require('../../src/utils/errors');
 
 /**
@@ -47,7 +46,7 @@ function BackboneViewWidget(template, childView, context, parentView) {
       // Any other value is treated as a parent model lookup
       this.model = parentView.model.getDeep(scope);
     } else {
-      logger.warn(errors.childViewWasPassedAsObjectWithoutAScopeProperty());
+      errors.childViewWasPassedAsObjectWithoutAScopeProperty();
     }
   }
 }

--- a/adaptors/backbone/base_collection.js
+++ b/adaptors/backbone/base_collection.js
@@ -6,7 +6,6 @@
 var _ = require('underscore');
 var Backbone = require('backbone');
 var tungsten = require('../../src/tungsten');
-var logger = require('../../src/utils/logger');
 var errors = require('../../src/utils/errors');
 
 var eventTrigger = require('./event_trigger');
@@ -108,9 +107,9 @@ var BaseCollection = Backbone.Collection.extend({
       for (let i = 0; i < methods.length; i++) {
         if (protoProps[methods[i]]) {
           if (staticProps && staticProps.debugName) {
-            logger.warn(errors.collectionMethodMayNotBeOverridden(methods[i], staticProps.debugName));
+            errors.collectionMethodMayNotBeOverridden(methods[i], staticProps.debugName);
           } else {
-            logger.warn(errors.collectionMethodMayNotBeOverridden(methods[i]));
+            errors.collectionMethodMayNotBeOverridden(methods[i]);
           }
           // Replace attempted override with base version
           protoProps[methods[i]] = wrapOverride(BaseCollection.prototype[methods[i]], protoProps[methods[i]]);
@@ -248,7 +247,7 @@ BaseCollection.prototype.reset = function(models, options = {}) {
         }
       }
       if (!allObjects || !_.isArray(this.initialData)) {
-        logger.warn(errors.collectionExpectedArrayOfObjectsButGot(initialStr));
+        errors.collectionExpectedArrayOfObjectsButGot(initialStr);
       }
     }
   }

--- a/adaptors/backbone/base_model.js
+++ b/adaptors/backbone/base_model.js
@@ -5,7 +5,6 @@
 var _ = require('underscore');
 var Backbone = require('backbone');
 var tungsten = require('../../src/tungsten');
-var logger = require('../../src/utils/logger');
 var errors = require('../../src/utils/errors');
 var ComponentWidget = require('./component_widget');
 var eventTrigger = require('./event_trigger');
@@ -564,7 +563,7 @@ BaseModel.prototype.set = function(key, val, options) {
       delete options.initialData;
       this.initialData = JSON.parse(initialStr || '{}');
       if (!_.isObject(this.initialData) || _.isArray(this.initialData)) {
-        logger.warn(errors.modelExpectedObjectOfAttributesButGot(initialStr));
+        errors.modelExpectedObjectOfAttributesButGot(initialStr);
       }
     }
 

--- a/adaptors/backbone/base_model.js
+++ b/adaptors/backbone/base_model.js
@@ -67,9 +67,9 @@ var BaseModel = Backbone.Model.extend({
       for (let i = 0; i < methods.length; i++) {
         if (protoProps[methods[i]]) {
           if (staticProps && staticProps.debugName) {
-            logger.warn(errors.modelMethodMayNotBeOverridden(methods[i], staticProps.debugName));
+            errors.modelMethodMayNotBeOverridden(methods[i], staticProps.debugName);
           } else {
-            logger.warn(errors.modelMethodMayNotBeOverridden(methods[i]));
+            errors.modelMethodMayNotBeOverridden(methods[i]);
           }
           // Replace attempted override with base version
           protoProps[methods[i]] = wrapOverride(BaseModel.prototype[methods[i]], protoProps[methods[i]]);

--- a/adaptors/backbone/base_view.js
+++ b/adaptors/backbone/base_view.js
@@ -7,7 +7,6 @@
 var _ = require('underscore');
 var Backbone = require('backbone');
 var tungsten = require('../../src/tungsten');
-var logger = require('../../src/utils/logger');
 var errors = require('../../src/utils/errors');
 var ViewWidget = require('./backbone_view_widget');
 var ComponentWidget = require('./component_widget');
@@ -182,7 +181,7 @@ var BaseView = Backbone.View.extend({
       // Compare full template against full DOM
       var diff = this.getTemplateDiff();
       if (diff.indexOf('<ins>') + diff.indexOf('<del>') > -2) {
-        logger.warn(errors.domDoesNotMatchVDOMForView(this.getDebugName()));
+        errors.domDoesNotMatchVDOMForView(this.getDebugName());
       }
     }
   },
@@ -421,9 +420,9 @@ var BaseView = Backbone.View.extend({
       for (var i = 0; i < methods.length; i++) {
         if (protoProps[methods[i]]) {
           if (staticProps && staticProps.debugName) {
-            logger.warn(errors.viewMethodMayNotBeOverridden(methods[i], staticProps.debugName));
+            errors.viewMethodMayNotBeOverridden(methods[i], staticProps.debugName);
           } else {
-            logger.warn(errors.viewMethodMayNotBeOverridden(methods[i]));
+            errors.viewMethodMayNotBeOverridden(methods[i]);
           }
           // Replace attempted override with base version
           protoProps[methods[i]] = wrapOverride(BaseView.prototype[methods[i]], protoProps[methods[i]]);

--- a/adaptors/backbone/component_widget.js
+++ b/adaptors/backbone/component_widget.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var _ = require('underscore');
-var logger = require('../../src/utils/logger');
 var errors = require('../../src/utils/errors');
 
 var modelFunctionsToMap = ['trigger', 'set', 'get', 'has', 'doSerialize', 'save', 'fetch', 'sync', 'validate', 'isValid'];
@@ -9,7 +8,7 @@ var modelFunctionsToDummy = ['on', 'off', 'listenTo'];
 
 var getDummyFunction = function(fn) {
   return function() {
-    logger.warn(errors.componentFunctionMayNotBeCalledDirectly(fn));
+    errors.componentFunctionMayNotBeCalledDirectly(fn);
   };
 };
 
@@ -58,7 +57,7 @@ function ComponentWidget(ViewConstructor, model, template, options, key) {
       if (typeof this[fn] === 'undefined') {
         this[fn] = _.bind(model[fn], model);
       } else {
-        logger.warn(errors.cannotOverwriteComponentMethod(fn));
+        errors.cannotOverwriteComponentMethod(fn);
       }
     }
   }

--- a/src/debug/panel_js/model_panel_events.js
+++ b/src/debug/panel_js/model_panel_events.js
@@ -82,7 +82,7 @@ module.exports = function() {
       appData.selectedModel.obj.set(key, value);
       appData.updateSelectedModel();
     } catch (ex) {
-      utils.alert(errors.unableToParseToAValidValueMustMatchJSONFormat(e.currentTarget.value));
+      errors.unableToParseToAValidValueMustMatchJSONFormat(e.currentTarget.value);
       utils.selectElements('js-model-property-value')[0].focus();
     }
   });

--- a/src/debug/panel_js/utils.js
+++ b/src/debug/panel_js/utils.js
@@ -37,7 +37,6 @@ function alert(message) {
   if (debugWindow) {
     debugWindow.alert(message);
   }
-  logger.warn(message);
 }
 
 function selectElements(className, docToSearch) {

--- a/src/debug/vtree_to_string.js
+++ b/src/debug/vtree_to_string.js
@@ -6,7 +6,6 @@
  */
 
 var _ = require('underscore');
-var logger = require('../utils/logger');
 var errors = require('../utils/errors');
 var syntaxHighlight = require('./syntax_highlight');
 
@@ -55,7 +54,7 @@ function toString(vtree, escaped) {
     if (typeof vtree.templateToString === 'function') {
       output += vtree.templateToString(toString);
     } else {
-      logger.warn(errors.widgetTypeHasNoTemplateToStringFunctionFallingBackToDOM(vtree.constructor.name));
+      errors.widgetTypeHasNoTemplateToStringFunctionFallingBackToDOM(vtree.constructor.name);
       var elem = vdom.create(virtualHyperscript('div', {}, vtree));
       output += elem.innerHTML;
     }

--- a/src/debug/window_manager.js
+++ b/src/debug/window_manager.js
@@ -27,7 +27,7 @@ function getWindow() {
   // Launch panel
   debugWindow = window.open('', 'TungstenDebugger', 'directories=no,titlebar=no,toolbar=no,location=no,status=no,menubar=no,width=800,height=640');
   if (!debugWindow) {
-    logger.error(errors.unableToLaunchDebugPanel());
+    errors.unableToLaunchDebugPanel();
   } else {
     debugWindow.document.title = 'DEBUG: ' + window.document.title;
     debugWindow.onerror = collectError;

--- a/src/event/events_core.js
+++ b/src/event/events_core.js
@@ -137,10 +137,12 @@ module.exports.removeEvent = function(evt) {
     } else if (evt.length === 4) {
       removeElementEvents(evt[0], evt[1], evt[2], evt[3]);
     } else {
-      logger.warn(errors.objectDoesNotMeetExpectedEventSpec(), evt);
+      errors.objectDoesNotMeetExpectedEventSpec();
+      logger.warn(evt);
     }
   } else {
-    logger.warn(errors.objectDoesNotMeetExpectedEventSpec(), evt);
+    errors.objectDoesNotMeetExpectedEventSpec();
+    logger.warn(evt);
   }
 };
 

--- a/src/event/events_core.js
+++ b/src/event/events_core.js
@@ -3,7 +3,6 @@
 var dataset = require('data-set');
 var eventWrapper = require('./tungsten_event');
 var _ = require('underscore');
-var logger = require('../utils/logger');
 var errors = require('../utils/errors');
 
 module.exports = {};
@@ -137,12 +136,10 @@ module.exports.removeEvent = function(evt) {
     } else if (evt.length === 4) {
       removeElementEvents(evt[0], evt[1], evt[2], evt[3]);
     } else {
-      errors.objectDoesNotMeetExpectedEventSpec();
-      logger.warn(evt);
+      errors.objectDoesNotMeetExpectedEventSpec(evt);
     }
   } else {
-    errors.objectDoesNotMeetExpectedEventSpec();
-    logger.warn(evt);
+    errors.objectDoesNotMeetExpectedEventSpec(evt);
   }
 };
 

--- a/src/template/adaptor.js
+++ b/src/template/adaptor.js
@@ -3,7 +3,6 @@
 var _ = require('underscore');
 var ToString = require('./stacks/string');
 var Context = require('./template_context');
-var logger = require('./../utils/logger');
 var errors = require('./../utils/errors');
 var types = require('./types');
 var virtualDomImplementation = require('../vdom/virtual_dom_implementation');
@@ -162,7 +161,7 @@ function render(stack, template, context, partials, parentView) {
         }
       } else {
         // @TODO, perhaps return this string as the partial result so it renders to the page?
-        logger.warn(errors.warningNoPartialRegisteredWithTheName(partialName));
+        errors.warningNoPartialRegisteredWithTheName(partialName);
       }
       break;
 
@@ -347,7 +346,7 @@ var attachView = function(view, template, createWidget, partials, childClasses) 
   if (template.t === types.PARTIAL) {
     var partialName = template.r;
     if (!partials[partialName]) {
-      logger.warn(errors.warningNoPartialRegisteredWithTheName(partialName));
+      errors.warningNoPartialRegisteredWithTheName(partialName);
       return null;
     } else {
       var partialTemplate = partials[partialName];

--- a/src/template/compiler/compiler_errors.js
+++ b/src/template/compiler/compiler_errors.js
@@ -1,0 +1,104 @@
+/**
+ * Container for generic compiler error messages that can be extended based on needs
+ *
+ * @author    Henry Morgan <hemorgan@wayfair.com>
+ */
+'use strict';
+
+const compilerLogger = require('./compiler_logger');
+const _ = require('underscore');
+
+module.exports = {};
+
+/**
+ * Compiler error messages, categorized by type.
+ * Each message must be in a function. This function must return either a string, or an array whose first element is a string
+ * @type {Object}
+ */
+var messages = {
+  warn: {
+    elementIsAVoidElementSoDoesNotNeedAClosingTag: (name) => `${name} is a void element so does not need a closing tag`,
+    cannotPlaceThisTagWithinAPreviousTag: (value, prevTagName, isValid) => `Cannot place this ${value} tag within a ${prevTagName} tag. ${isValid}`,
+    templateContainsUnclosedItems: (stack) => ['Template contains unclosed items', stack],
+    mustacheTokenCannotBeInAttributeNames: (token) => ['Mustache token cannot be in attribute names', token],
+    doubleCurlyInterpolatorsCannotBeInAttributes: (itemValue) => ['Double curly interpolators cannot be in attributes', itemValue]
+  },
+  exception: {
+    notAllTagsWereClosedProperly: (stack) => ['Not all tags were closed properly', stack],
+    wrongClosingElementType: (name, current) => `</${name}> where a </${current}> should be`,
+    closingHTMLElementWithNoPair: (closingElemTagName) => `</${closingElemTagName}> with no paired <${closingElemTagName}>`,
+    closingMustacheElementWithNoPair: (closingElemValue) => `{{/${closingElemValue}}} with no paired {{#${closingElemValue}}}`,
+    tagIsClosedBeforeOpenTagIsCompletedCheckForUnpairedQuotes: () => 'Tag is closed before open tag is completed. Check for unpaired quotes',
+    differentTagThanExpected: (actualTag, expectedTag) => `${actualTag} where a ${expectedTag} should be`
+  }
+};
+
+/**
+ * Returns a compilerLogger call with the provided message and type
+ * @param  {function} message  function that returns an array containing the message and any additional arguments
+ * @param  {string} type The type of log to make (warning or exception)
+ * @return {function}      Function that calls compilerLogger with the provided message and type
+ */
+function compilerLoggerize(message, type) {
+  return function() {
+    let output = message.apply(message, arguments);
+
+    // Make output always be an array.
+    // (compilerLogger expects a series of arguments. For apply to work correctly we must provide an array.)
+    if (!_.isArray(output)) {
+      output = [output];
+    }
+    compilerLogger[type].apply(compilerLogger, output);
+
+    // Return the message in case it's needed. (I.E. for utils.alert)
+    return output;
+  };
+}
+
+/**
+ * Extends a generic error message with custom information (i.e. implementation-specific hints)
+ * and then adds the compilerLoggerized version of the extended message to module.exports.
+ * @param  {string} errorName The name of the error function to extend
+ * @param  {string} customMsg The custom message to append to the generic error message.
+ */
+function extend(errorName, customMsg) {
+  // Find our error message
+  for (let type in messages) {
+    if (messages[type][errorName]) {
+      // Extend the error message
+      let origError = messages[type][errorName];
+      // If origError returns multiple arguments, access the first (the error message) and append to it.
+      if (_.isArray(origError())) {
+        messages[type][errorName] = function() {
+          let errorMessage = origError.apply(origError, arguments);
+          errorMessage[0] = `${errorMessage[0]}. ${customMsg}`;
+          return errorMessage;
+        };
+      } else {
+        // Otherwise, simply append to the message.
+        messages[type][errorName] = function() {
+          return `${origError.apply(origError, arguments)}. ${customMsg}`;
+        };
+      }
+      // compilerLoggerize the message and add it to module.exports.
+      module.exports[errorName] = compilerLoggerize(messages[type][errorName], type);
+      return;
+    }
+  }
+
+  // No error was found matching the name provided.
+  compilerLogger.warn(`Tried to extend a nonexistent error message: ${errorName}`);
+}
+
+module.exports.extend = extend;
+
+// For each log type, loggerize each message and add it to module.exports
+for (let type in messages) {
+  if (messages[type]) {
+    for (let msgName in messages[type]) {
+      if (messages[type].hasOwnProperty(msgName)) {
+        module.exports[msgName] = compilerLoggerize(messages[type][msgName], type);
+      }
+    }
+  }
+}

--- a/src/template/compiler/compiler_errors.js
+++ b/src/template/compiler/compiler_errors.js
@@ -94,11 +94,7 @@ module.exports.extend = extend;
 
 // For each log type, loggerize each message and add it to module.exports
 for (let type in messages) {
-  if (messages[type]) {
-    for (let msgName in messages[type]) {
-      if (messages[type].hasOwnProperty(msgName)) {
-        module.exports[msgName] = compilerLoggerize(messages[type][msgName], type);
-      }
-    }
+  for (let msgName in messages[type]) {
+    module.exports[msgName] = compilerLoggerize(messages[type][msgName], type);
   }
 }

--- a/src/template/compiler/index.js
+++ b/src/template/compiler/index.js
@@ -5,7 +5,6 @@ const _ = require('underscore');
 const parser = require('./parser');
 const stack = require('./stack');
 const logger = require('./compiler_logger');
-const errors = require('../../utils/errors');
 const processTemplate = require('./languages/mustache');
 
 /**
@@ -44,8 +43,7 @@ function getTemplate(template, options) {
   let output = {};
 
   if (stack.stack.length > 0) {
-    errors.notAllTagsWereClosedProperly();
-    logger.exception(stack.stack);
+    logger.exception('Not all tags were closed properly', stack.stack);
   }
 
   parser.end();

--- a/src/template/compiler/index.js
+++ b/src/template/compiler/index.js
@@ -44,7 +44,8 @@ function getTemplate(template, options) {
   let output = {};
 
   if (stack.stack.length > 0) {
-    logger.exception(errors.notAllTagsWereClosedProperly(), stack.stack);
+    errors.notAllTagsWereClosedProperly();
+    logger.exception(stack.stack);
   }
 
   parser.end();

--- a/src/template/compiler/index.js
+++ b/src/template/compiler/index.js
@@ -4,7 +4,8 @@ const _ = require('underscore');
 
 const parser = require('./parser');
 const stack = require('./stack');
-const logger = require('./compiler_logger');
+const compilerLogger = require('./compiler_logger');
+const compilerErrors = require('./compiler_errors');
 const processTemplate = require('./languages/mustache');
 
 /**
@@ -32,8 +33,8 @@ function getTemplate(template, options) {
   opts.lambdas = lambdas;
   opts.processingHTML = typeof opts.processingHTML === 'boolean' ? opts.processingHTML : true;
 
-  logger.setStrictMode(opts.strict);
-  logger.setOverrides(opts.logger);
+  compilerLogger.setStrictMode(opts.strict);
+  compilerLogger.setOverrides(opts.logger);
   stack.setHtmlValidation(opts.validateHtml);
 
   let templateStr = template.toString();
@@ -43,7 +44,7 @@ function getTemplate(template, options) {
   let output = {};
 
   if (stack.stack.length > 0) {
-    logger.exception('Not all tags were closed properly', stack.stack);
+    compilerErrors.notAllTagsWereClosedProperly(stack.stack);
   }
 
   parser.end();

--- a/src/template/compiler/languages/mustache.js
+++ b/src/template/compiler/languages/mustache.js
@@ -3,7 +3,7 @@
 const types = require('../../types');
 const parser = require('../parser');
 const stack = require('../stack');
-const logger = require('../compiler_logger');
+const compilerLogger = require('../compiler_logger');
 
 var templateTypes = {
   '#': types.SECTION,
@@ -196,7 +196,7 @@ function processTemplate(str, opts) {
   };
 
   // Set function to logger to show context around any parsing error
-  logger.setContextFunction(errorContext);
+  compilerLogger.setContextFunction(errorContext);
 
   templateString = str;
   inDynamicAttribute = false;
@@ -288,7 +288,7 @@ function processTemplate(str, opts) {
   processLine(opts);
 
   // Clear logger context function for next run
-  logger.setContextFunction();
+  compilerLogger.setContextFunction();
 }
 
 module.exports = processTemplate;

--- a/src/template/compiler/parser.js
+++ b/src/template/compiler/parser.js
@@ -3,7 +3,7 @@
 const Parser = require('htmlparser2/lib/Parser');
 const types = require('../types');
 const stack = require('./stack');
-const logger = require('./compiler_logger');
+const compilerErrors = require('./compiler_errors');
 const decoder = require('./decoder');
 
 // Taken from https://github.com/fb55/htmlparser2/blob/master/lib/Parser.js#L59
@@ -147,7 +147,7 @@ MustacheParser.prototype.onclosetag = function(name) {
   }
 
   if (name in voidElements) {
-    logger.warn(`${name} is a void element so does not need a closing tag`);
+    compilerErrors.elementIsAVoidElementSoDoesNotNeedAClosingTag(name);
     return;
   }
 
@@ -160,10 +160,10 @@ MustacheParser.prototype.onclosetag = function(name) {
       }
     } else {
       let current = this._stack[this._stack.length - 1];
-      logger.exception(`</${name}> where a </${current}> should be`);
+      compilerErrors.wrongClosingElementType(name, current);
     }
   } else {
-    logger.exception(`</${name}> with no paired <${name}>`);
+    compilerErrors.closingHTMLElementWithNoPair(name);
   }
 };
 

--- a/src/template/compiler/parser.js
+++ b/src/template/compiler/parser.js
@@ -4,7 +4,6 @@ const Parser = require('htmlparser2/lib/Parser');
 const types = require('../types');
 const stack = require('./stack');
 const logger = require('./compiler_logger');
-const errors = require('../../utils/errors');
 const decoder = require('./decoder');
 
 // Taken from https://github.com/fb55/htmlparser2/blob/master/lib/Parser.js#L59
@@ -148,7 +147,7 @@ MustacheParser.prototype.onclosetag = function(name) {
   }
 
   if (name in voidElements) {
-    errors.elementIsAVoidElementSoDoesNotNeedAClosingTag(name);
+    logger.warn(`${name} is a void element so does not need a closing tag`);
     return;
   }
 
@@ -161,10 +160,10 @@ MustacheParser.prototype.onclosetag = function(name) {
       }
     } else {
       let current = this._stack[this._stack.length - 1];
-      errors.wrongClosingElementType(name, current);
+      logger.exception(`</${name}> where a </${current}> should be`);
     }
   } else {
-    errors.closingHTMLElementWithNoPair(name);
+    logger.exception(`</${name}> with no paired <${name}>`);
   }
 };
 

--- a/src/template/compiler/parser.js
+++ b/src/template/compiler/parser.js
@@ -148,7 +148,7 @@ MustacheParser.prototype.onclosetag = function(name) {
   }
 
   if (name in voidElements) {
-    logger.warn(errors.elementIsAVoidElementSoDoesNotNeedAClosingTag(name));
+    errors.elementIsAVoidElementSoDoesNotNeedAClosingTag(name);
     return;
   }
 
@@ -161,10 +161,10 @@ MustacheParser.prototype.onclosetag = function(name) {
       }
     } else {
       let current = this._stack[this._stack.length - 1];
-      logger.exception(errors.wrongClosingElementType(name, current));
+      errors.wrongClosingElementType(name, current);
     }
   } else {
-    logger.exception(errors.closingHTMLElementWithNoPair(name));
+    errors.closingHTMLElementWithNoPair(name);
   }
 };
 

--- a/src/template/compiler/stack.js
+++ b/src/template/compiler/stack.js
@@ -4,7 +4,6 @@ const _ = require('underscore');
 const types = require('../types');
 const htmlHelpers = require('../html_helpers');
 const logger = require('./compiler_logger');
-const errors = require('../../utils/errors');
 
 // Keys to use for the outputted array
 const templateKeys = {
@@ -105,7 +104,7 @@ templateStack.openElement = function(type, value) {
     if (prev && this.htmlValidationMode) {
       let isValid = htmlHelpers.validation.isValidChild(prev, value, this.htmlValidationMode === 'strict');
       if (isValid !== true) {
-        errors.cannotPlaceThisTagWithinAPreviousTag(value, prev.tagName, isValid);
+        logger.warn(`Cannot place this ${value} tag within a ${prev.tagName} tag. ${isValid}`);
       }
     }
     elem.childTags = {};
@@ -217,7 +216,7 @@ templateStack._closeElem = function(obj) {
   let i;
 
   if (obj.isOpen) {
-    errors.tagIsClosedBeforeOpenTagIsCompletedCheckForUnpairedQuotes();
+    logger.exception('Tag is closed before open tag is completed. Check for unpaired quotes');
     // Close the element off to avoid other errors
     obj.close();
   }
@@ -309,7 +308,7 @@ templateStack.closeElement = function(closingElem) {
       } else {
         actualTag = '{{/' + closingElem.value + '}}';
       }
-      errors.differentTagThanExpected(actualTag, expectedTag);
+      logger.exception(`${actualTag} where a ${expectedTag} should be`);
     } else {
       // If they match, everything lines up
       this._closeElem(this.stack.pop());
@@ -317,9 +316,9 @@ templateStack.closeElement = function(closingElem) {
   } else {
     if (closingElem.tagName) {
       // Something has gone terribly wrong
-      errors.closingHTMLElementWithNoPair(closingElem.tagName);
+      logger.exception(`</${closingElem.tagName}> with no paired <${closingElem.tagName}>`);
     } else {
-      errors.closingMustacheElementWithNoPair(closingElem.value);
+      logger.exception(`{{/${closingElem.value}}} with no paired {{#${closingElem.value}}}`);
     }
   }
 };
@@ -327,8 +326,7 @@ templateStack.closeElement = function(closingElem) {
 templateStack.getOutput = function() {
   // If any items are left on the stack, they weren't closed by the template
   if (this.stack.length) {
-    errors.templateContainsUnclosedItems();
-    logger.warn(this.stack);
+    logger.warn('Template contains unclosed items', this.stack);
   }
   // Always return the array
   return this.result;
@@ -389,8 +387,7 @@ function processAttributeArray(attrArray) {
       // Ensure there are no tokens in a non-dynamic attribute name
       for (let j = 0; j < name.length; j++) {
         if (typeof name[j] !== 'string') {
-          errors.mustacheTokenCannotBeInAttributeNames();
-          logger.warn(name[j]);
+          logger.warn('Mustache token cannot be in attribute names', name[j]);
         }
       }
 
@@ -419,8 +416,7 @@ function processAttributeArray(attrArray) {
     } else if (pushingTo === name) {
       if (name.length === 0) {
         if (item.type === types.INTERPOLATOR) {
-          errors.doubleCurlyInterpolatorsCannotBeInAttributes();
-          logger.warn(item.value);
+          logger.warn('Double curly interpolators cannot be in attributes', item.value);
         } else if (item.type === types.SECTION) {
           attrs.dynamic.push(templateStack.processObject(item));
           continue;

--- a/src/template/compiler/stack.js
+++ b/src/template/compiler/stack.js
@@ -105,7 +105,7 @@ templateStack.openElement = function(type, value) {
     if (prev && this.htmlValidationMode) {
       let isValid = htmlHelpers.validation.isValidChild(prev, value, this.htmlValidationMode === 'strict');
       if (isValid !== true) {
-        logger.warn(errors.cannotPlaceThisTagWithinAPreviousTag(value, prev.tagName, isValid));
+        errors.cannotPlaceThisTagWithinAPreviousTag(value, prev.tagName, isValid);
       }
     }
     elem.childTags = {};
@@ -217,7 +217,7 @@ templateStack._closeElem = function(obj) {
   let i;
 
   if (obj.isOpen) {
-    logger.exception(errors.tagIsClosedBeforeOpenTagIsCompletedCheckForUnpairedQuotes());
+    errors.tagIsClosedBeforeOpenTagIsCompletedCheckForUnpairedQuotes();
     // Close the element off to avoid other errors
     obj.close();
   }
@@ -309,7 +309,7 @@ templateStack.closeElement = function(closingElem) {
       } else {
         actualTag = '{{/' + closingElem.value + '}}';
       }
-      logger.exception(errors.differentTagThanExpected(actualTag, expectedTag));
+      errors.differentTagThanExpected(actualTag, expectedTag);
     } else {
       // If they match, everything lines up
       this._closeElem(this.stack.pop());
@@ -317,9 +317,9 @@ templateStack.closeElement = function(closingElem) {
   } else {
     if (closingElem.tagName) {
       // Something has gone terribly wrong
-      logger.exception(errors.closingHTMLElementWithNoPair(closingElem.tagName));
+      errors.closingHTMLElementWithNoPair(closingElem.tagName);
     } else {
-      logger.exception(errors.closingMustacheElementWithNoPair(closingElem.value));
+      errors.closingMustacheElementWithNoPair(closingElem.value);
     }
   }
 };
@@ -327,7 +327,8 @@ templateStack.closeElement = function(closingElem) {
 templateStack.getOutput = function() {
   // If any items are left on the stack, they weren't closed by the template
   if (this.stack.length) {
-    logger.warn(errors.templateContainsUnclosedItems(), this.stack);
+    errors.templateContainsUnclosedItems();
+    logger.warn(this.stack);
   }
   // Always return the array
   return this.result;
@@ -388,7 +389,8 @@ function processAttributeArray(attrArray) {
       // Ensure there are no tokens in a non-dynamic attribute name
       for (let j = 0; j < name.length; j++) {
         if (typeof name[j] !== 'string') {
-          logger.warn(errors.mustacheTokenCannotBeInAttributeNames(), name[j]);
+          errors.mustacheTokenCannotBeInAttributeNames();
+          logger.warn(name[j]);
         }
       }
 
@@ -417,7 +419,8 @@ function processAttributeArray(attrArray) {
     } else if (pushingTo === name) {
       if (name.length === 0) {
         if (item.type === types.INTERPOLATOR) {
-          logger.warn(errors.doubleCurlyInterpolatorsCannotBeInAttributes(), item.value);
+          errors.doubleCurlyInterpolatorsCannotBeInAttributes();
+          logger.warn(item.value);
         } else if (item.type === types.SECTION) {
           attrs.dynamic.push(templateStack.processObject(item));
           continue;

--- a/src/template/stacks/default.js
+++ b/src/template/stacks/default.js
@@ -2,7 +2,6 @@
 
 var document = require('global/document');
 var processProperties = require('../process_properties');
-var logger = require('../../utils/logger');
 var errors = require('../../utils/errors');
 
 // IE8 and back don't create whitespace-only nodes from the DOM
@@ -155,7 +154,7 @@ DefaultStack.prototype.closeElement = function(closingElem) {
   if (openElem) {
     var openID = openElem.id;
     if (openID !== id) {
-      logger.warn(errors.tagsImproperlyPairedClosing(tagName, openID, id));
+      errors.tagsImproperlyPairedClosing(tagName, openID, id);
       do {
         openElem = this.stack.pop();
         this._closeElem(openElem);
@@ -170,7 +169,7 @@ DefaultStack.prototype.closeElement = function(closingElem) {
     this.closeElement(this.openElement('p', {}));
   } else {
     // Something has gone terribly wrong
-    logger.warn(errors.closingElementWhenTheStackWasEmpty(id));
+    errors.closingElementWhenTheStackWasEmpty(id);
   }
 };
 

--- a/src/template/template_context.js
+++ b/src/template/template_context.js
@@ -208,7 +208,7 @@ Context.prototype.lookup = function(name, handleLambda) {
           } else {
             if (computedPropertyWarnings[name] !== true) {
               computedPropertyWarnings[name] = true;
-              logger.warn(errors.computedPropertiesAreNowDeprecatedPleaseChange(name));
+              errors.computedPropertiesAreNowDeprecatedPleaseChange(name);
             }
             value = value.call(fnContext);
           }

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -7,57 +7,100 @@
 
 const logger = require('./logger');
 
-/**
- * Extends a generic error message with custom information, i.e. implementation-specific hints
- * @param  {string} error The name of the error function to extend
- * @param  {string} customMsg The custom message to append to the generic error message.
- */
-function extend(error, customMsg) {
-  if (!this.hasOwnProperty(error)) {
-    logger.warn(`Tried to extend a nonexistent error message: ${error}`);
-    return;
+module.exports = {
+  extend: extend
+};
+
+// Error messages, categorized by type. (logger.warn, logger.error, etc...)
+var messages = {
+  warn: {
+    childViewWasPassedAsObjectWithoutAScopeProperty: () => 'ChildView was passed as object without a scope property',
+    collectionMethodMayNotBeOverridden: function(methodName, debugName) {
+      return `Collection.${methodName} may not be overridden` + (debugName ? ` for collection "${debugName}"` : '');
+    },
+    collectionExpectedArrayOfObjectsButGot: (initialStr) => `Collection expected array of objects but got: ${initialStr}`,
+    modelMethodMayNotBeOverridden: function(methodName, debugName) {
+      return `Model.${methodName} may not be overridden` + (debugName ? ` for model "${debugName}"` : '');
+    },
+    modelExpectedObjectOfAttributesButGot: (initialStr) => `Model expected object of attributes but got: ${initialStr}`,
+    domDoesNotMatchVDOMForView: (debugName) => `DOM does not match VDOM for view "${debugName}". Use debug panel to see differences`,
+    viewMethodMayNotBeOverridden: function(methodName, debugName) {
+      return `View.${methodName} may not be overridden` + (debugName ? ` for view "${debugName}"` : '');
+    },
+    componentFunctionMayNotBeCalledDirectly: (fn) => `Component.${fn} may not be called directly`,
+    cannotOverwriteComponentMethod: (fn) => `Cannot overwrite component method: ${fn}`,
+    unableToParseToAValidValueMustMatchJSONFormat: (value) => `Unable to parse "${value}" to a valid value. Input must match JSON format`,
+    widgetTypeHasNoTemplateToStringFunctionFallingBackToDOM: (name) => `Widget type: ${name} has no templateToString function, falling back to DOM`,
+    objectDoesNotMeetExpectedEventSpec: () => 'Object does not meet expected event spec',
+    warningNoPartialRegisteredWithTheName: (partialName) => `Warning: no partial registered with the name ${partialName}`,
+    elementIsAVoidElementSoDoesNotNeedAClosingTag: (name) => `${name} is a void element so does not need a closing tag`,
+    cannotPlaceThisTagWithinAPreviousTag: (value, prevTagName, isValid) => `Cannot place this ${value} tag within a ${prevTagName} tag. ${isValid}`,
+    templateContainsUnclosedItems: () => 'Template contains unclosed items',
+    mustacheTokenCannotBeInAttributeNames: () => 'Mustache token cannot be in attribute names',
+    doubleCurlyInterpolatorsCannotBeInAttributes: () => 'Double curly interpolators cannot be in attributes',
+    tagsImproperlyPairedClosing: (tagName, openID, id) => `${tagName} tags improperly paired, closing ${openID} with close tag from ${id}`,
+    closingElementWhenTheStackWasEmpty: (id) => `Closing element ${id} when the stack was empty`,
+    computedPropertiesAreNowDeprecatedPleaseChange: (name) => `Computed properties are now deprecated and will be removed soon. Please change "${name}" to a derived property`
+  },
+  error: {
+    unableToLaunchDebugPanel: () => 'Unable to launch debug panel. You may need to allow the popup or run "window.launchDebugger()" from your console'
+  },
+  exception: {
+    notAllTagsWereClosedProperly: () => 'Not all tags were closed properly',
+    wrongClosingElementType: (name, current) => `</${name}> where a </${current}> should be`,
+    tagIsClosedBeforeOpenTagIsCompletedCheckForUnpairedQuotes: () => 'Tag is closed before open tag is completed. Check for unpaired quotes',
+    differentTagThanExpected: (actualTag, expectedTag) => `${actualTag} where a ${expectedTag} should be`,
+    closingHTMLElementWithNoPair: (closingElemTagName) => `</${closingElemTagName}> with no paired <${closingElemTagName}>`,
+    closingMustacheElementWithNoPair: (closingElemValue) => `{{/${closingElemValue}}} with no paired {{#${closingElemValue}}}`
   }
-  let origError = this[error];
-  this[error] = function() {
-    return `${origError.apply(origError, arguments)}. ${customMsg}`;
-  };
+};
+// For each log type, loggerize each message and add it to module.exports
+for (let type in messages) {
+  if (messages.hasOwnProperty(type)) {
+    for (let msgName in messages[type]) {
+      if (messages[type].hasOwnProperty(msgName)) {
+        module.exports[msgName] = loggerize(messages[type][msgName], type);
+      }
+    }
+  }
 }
 
-module.exports = {
-  extend: extend,
+/**
+ * Extends a generic error message with custom information (i.e. implementation-specific hints)
+ * and then adds the loggerized version of the extended message to module.exports.
+ * @param  {string} errorName The name of the error function to extend
+ * @param  {string} customMsg The custom message to append to the generic error message.
+ */
+function extend(errorName, customMsg) {
 
-  childViewWasPassedAsObjectWithoutAScopeProperty: () => 'ChildView was passed as object without a scope property',
-  collectionMethodMayNotBeOverridden: function(methodName, debugName) {
-    return `Collection.${methodName} may not be overridden` + (debugName ? ` for collection "${debugName}"` : '');
-  },
-  collectionExpectedArrayOfObjectsButGot: (initialStr) => `Collection expected array of objects but got: ${initialStr}`,
-  modelMethodMayNotBeOverridden: function(methodName, debugName) {
-    return `Model.${methodName} may not be overridden` + (debugName ? ` for model "${debugName}"` : '');
-  },
-  modelExpectedObjectOfAttributesButGot: (initialStr) => `Model expected object of attributes but got: ${initialStr}`,
-  domDoesNotMatchVDOMForView: (debugName) => `DOM does not match VDOM for view "${debugName}". Use debug panel to see differences`,
-  viewMethodMayNotBeOverridden: function(methodName, debugName) {
-    return `View.${methodName} may not be overridden` + (debugName ? ` for view "${debugName}"` : '');
-  },
-  componentFunctionMayNotBeCalledDirectly: (fn) => `Component.${fn} may not be called directly`,
-  cannotOverwriteComponentMethod: (fn) => `Cannot overwrite component method: ${fn}`,
-  unableToParseToAValidValueMustMatchJSONFormat: (value) => `Unable to parse "${value}" to a valid value. Input must match JSON format`,
-  widgetTypeHasNoTemplateToStringFunctionFallingBackToDOM: (name) => `Widget type: ${name} has no templateToString function, falling back to DOM`,
-  unableToLaunchDebugPanel: () => 'Unable to launch debug panel. You may need to allow the popup or run "window.launchDebugger()" from your console',
-  objectDoesNotMeetExpectedEventSpec: () => 'Object does not meet expected event spec',
-  warningNoPartialRegisteredWithTheName: (partialName) => `Warning: no partial registered with the name ${partialName}`,
-  notAllTagsWereClosedProperly: () => 'Not all tags were closed properly',
-  elementIsAVoidElementSoDoesNotNeedAClosingTag: (name) => `${name} is a void element so does not need a closing tag`,
-  wrongClosingElementType: (name, current) => `</${name}> where a </${current}> should be`,
-  cannotPlaceThisTagWithinAPreviousTag: (value, prevTagName, isValid) => `Cannot place this ${value} tag within a ${prevTagName} tag. ${isValid}`,
-  tagIsClosedBeforeOpenTagIsCompletedCheckForUnpairedQuotes: () => 'Tag is closed before open tag is completed. Check for unpaired quotes',
-  differentTagThanExpected: (actualTag, expectedTag) => `${actualTag} where a ${expectedTag} should be`,
-  closingHTMLElementWithNoPair: (closingElemTagName) => `</${closingElemTagName}> with no paired <${closingElemTagName}>`,
-  closingMustacheElementWithNoPair: (closingElemValue) => `{{/${closingElemValue}}} with no paired {{#${closingElemValue}}}`,
-  templateContainsUnclosedItems: () => 'Template contains unclosed items',
-  mustacheTokenCannotBeInAttributeNames: () => 'Mustache token cannot be in attribute names',
-  doubleCurlyInterpolatorsCannotBeInAttributes: () => 'Double curly interpolators cannot be in attributes',
-  tagsImproperlyPairedClosing: (tagName, openID, id) => `${tagName} tags improperly paired, closing ${openID} with close tag from ${id}`,
-  closingElementWhenTheStackWasEmpty: (id) => `Closing element ${id} when the stack was empty`,
-  computedPropertiesAreNowDeprecatedPleaseChange: (name) => `Computed properties are now deprecated and will be removed soon. Please change "${name}" to a derived property`
-};
+  // Find our error message
+  for (let type in messages) {
+    if (messages[type].hasOwnProperty(errorName)) {
+      // Extend the error message
+      let origError = messages[type][errorName];
+      messages[type][errorName] = function() {
+        return `${origError.apply(origError, arguments)}. ${customMsg}`;
+      };
+      // Loggerize the message and add it to module.exports.
+      module.exports[errorName] = loggerize(messages[type][errorName], type);
+      return;
+    }
+  }
+
+  // No error was found matching the name provided.
+  logger.warn(`Tried to extend a nonexistent error message: ${errorName}`);
+}
+
+/**
+ * Returns a logger call with the provided message and type
+ * @param  {function} msg  function that returns our message
+ * @param  {string} type The type of log to make (warning, error, exception, etc...)
+ * @return {function}      Function that calls logger with the provided message and type
+ */
+function loggerize(msg, type) {
+  return function() {
+    logger[type](msg());
+    // Return the message in case it's needed. (I.E. for utils.alert)
+    return msg();
+  };
+}

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -7,9 +7,7 @@
 
 const logger = require('./logger');
 
-module.exports = {
-  extend: extend
-};
+module.exports = {};
 
 // Error messages, categorized by type. (logger.warn, logger.error, etc...)
 var messages = {
@@ -33,7 +31,6 @@ var messages = {
     widgetTypeHasNoTemplateToStringFunctionFallingBackToDOM: (name) => `Widget type: ${name} has no templateToString function, falling back to DOM`,
     objectDoesNotMeetExpectedEventSpec: () => 'Object does not meet expected event spec',
     warningNoPartialRegisteredWithTheName: (partialName) => `Warning: no partial registered with the name ${partialName}`,
-    cannotPlaceThisTagWithinAPreviousTag: (value, prevTagName, isValid) => `Cannot place this ${value} tag within a ${prevTagName} tag. ${isValid}`,
     doubleCurlyInterpolatorsCannotBeInAttributes: () => 'Double curly interpolators cannot be in attributes',
     tagsImproperlyPairedClosing: (tagName, openID, id) => `${tagName} tags improperly paired, closing ${openID} with close tag from ${id}`,
     closingElementWhenTheStackWasEmpty: (id) => `Closing element ${id} when the stack was empty`,
@@ -45,15 +42,19 @@ var messages = {
   exception: {
   }
 };
-// For each log type, loggerize each message and add it to module.exports
-for (let type in messages) {
-  if (messages.hasOwnProperty(type)) {
-    for (let msgName in messages[type]) {
-      if (messages[type].hasOwnProperty(msgName)) {
-        module.exports[msgName] = loggerize(messages[type][msgName], type);
-      }
-    }
-  }
+
+/**
+ * Returns a logger call with the provided message and type
+ * @param  {function} message  function that returns our message
+ * @param  {string} type The type of log to make (warning, error, exception, etc...)
+ * @return {function}      Function that calls logger with the provided message and type
+ */
+function loggerize(message, type) {
+  return function() {
+    logger[type](message.apply(message, arguments));
+    // Return the message in case it's needed. (I.E. for utils.alert)
+    return message.apply(message, arguments);
+  };
 }
 
 /**
@@ -81,16 +82,16 @@ function extend(errorName, customMsg) {
   logger.warn(`Tried to extend a nonexistent error message: ${errorName}`);
 }
 
-/**
- * Returns a logger call with the provided message and type
- * @param  {function} message  function that returns our message
- * @param  {string} type The type of log to make (warning, error, exception, etc...)
- * @return {function}      Function that calls logger with the provided message and type
- */
-function loggerize(message, type) {
-  return function() {
-    logger[type](message());
-    // Return the message in case it's needed. (I.E. for utils.alert)
-    return message();
-  };
+module.exports.extend = extend;
+
+// For each log type, loggerize each message and add it to module.exports
+for (let type in messages) {
+  if (messages.hasOwnProperty(type)) {
+    for (let msgName in messages[type]) {
+      if (messages[type].hasOwnProperty(msgName)) {
+        module.exports[msgName] = loggerize(messages[type][msgName], type);
+      }
+    }
+  }
 }
+

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -33,10 +33,7 @@ var messages = {
     widgetTypeHasNoTemplateToStringFunctionFallingBackToDOM: (name) => `Widget type: ${name} has no templateToString function, falling back to DOM`,
     objectDoesNotMeetExpectedEventSpec: () => 'Object does not meet expected event spec',
     warningNoPartialRegisteredWithTheName: (partialName) => `Warning: no partial registered with the name ${partialName}`,
-    elementIsAVoidElementSoDoesNotNeedAClosingTag: (name) => `${name} is a void element so does not need a closing tag`,
     cannotPlaceThisTagWithinAPreviousTag: (value, prevTagName, isValid) => `Cannot place this ${value} tag within a ${prevTagName} tag. ${isValid}`,
-    templateContainsUnclosedItems: () => 'Template contains unclosed items',
-    mustacheTokenCannotBeInAttributeNames: () => 'Mustache token cannot be in attribute names',
     doubleCurlyInterpolatorsCannotBeInAttributes: () => 'Double curly interpolators cannot be in attributes',
     tagsImproperlyPairedClosing: (tagName, openID, id) => `${tagName} tags improperly paired, closing ${openID} with close tag from ${id}`,
     closingElementWhenTheStackWasEmpty: (id) => `Closing element ${id} when the stack was empty`,
@@ -46,12 +43,6 @@ var messages = {
     unableToLaunchDebugPanel: () => 'Unable to launch debug panel. You may need to allow the popup or run "window.launchDebugger()" from your console'
   },
   exception: {
-    notAllTagsWereClosedProperly: () => 'Not all tags were closed properly',
-    wrongClosingElementType: (name, current) => `</${name}> where a </${current}> should be`,
-    tagIsClosedBeforeOpenTagIsCompletedCheckForUnpairedQuotes: () => 'Tag is closed before open tag is completed. Check for unpaired quotes',
-    differentTagThanExpected: (actualTag, expectedTag) => `${actualTag} where a ${expectedTag} should be`,
-    closingHTMLElementWithNoPair: (closingElemTagName) => `</${closingElemTagName}> with no paired <${closingElemTagName}>`,
-    closingMustacheElementWithNoPair: (closingElemValue) => `{{/${closingElemValue}}} with no paired {{#${closingElemValue}}}`
   }
 };
 // For each log type, loggerize each message and add it to module.exports
@@ -72,7 +63,6 @@ for (let type in messages) {
  * @param  {string} customMsg The custom message to append to the generic error message.
  */
 function extend(errorName, customMsg) {
-
   // Find our error message
   for (let type in messages) {
     if (messages[type].hasOwnProperty(errorName)) {
@@ -93,14 +83,14 @@ function extend(errorName, customMsg) {
 
 /**
  * Returns a logger call with the provided message and type
- * @param  {function} msg  function that returns our message
+ * @param  {function} message  function that returns our message
  * @param  {string} type The type of log to make (warning, error, exception, etc...)
  * @return {function}      Function that calls logger with the provided message and type
  */
-function loggerize(msg, type) {
+function loggerize(message, type) {
   return function() {
-    logger[type](msg());
+    logger[type](message());
     // Return the message in case it's needed. (I.E. for utils.alert)
-    return msg();
+    return message();
   };
 }

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -11,6 +11,7 @@ const _ = require('underscore');
 module.exports = {};
 
 // Error messages, categorized by type. (logger.warn, logger.error, etc...)
+// First element in any returned array should be a string.
 var messages = {
   warn: {
     childViewWasPassedAsObjectWithoutAScopeProperty: () => 'ChildView was passed as object without a scope property',

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -10,8 +10,11 @@ const _ = require('underscore');
 
 module.exports = {};
 
-// Error messages, categorized by type. (logger.warn, logger.error, etc...)
-// First element in any returned array should be a string.
+/**
+ * Compiler error messages, categorized by type.
+ * Each message must be in a function. This function must return either a string, or an array whose first element is a string
+ * @type {Object}
+ */
 var messages = {
   warn: {
     childViewWasPassedAsObjectWithoutAScopeProperty: () => 'ChildView was passed as object without a scope property',
@@ -104,12 +107,8 @@ module.exports.extend = extend;
 
 // For each log type, loggerize each message and add it to module.exports
 for (let type in messages) {
-  if (messages[type]) {
-    for (let msgName in messages[type]) {
-      if (messages[type].hasOwnProperty(msgName)) {
-        module.exports[msgName] = loggerize(messages[type][msgName], type);
-      }
-    }
+  for (let msgName in messages[type]) {
+    module.exports[msgName] = loggerize(messages[type][msgName], type);
   }
 }
 

--- a/test/src/event/events_core_spec.js
+++ b/test/src/event/events_core_spec.js
@@ -76,9 +76,9 @@ describe('events_core.js public API', function() {
         console.warn.calls.reset();
         eventsCore.removeEvent(evt);
         jasmineExpect(console.warn).toHaveBeenCalledWith(
-          'Object does not meet expected event spec'
+          'Object does not meet expected event spec',
+          evt
         );
-        jasmineExpect(console.warn).toHaveBeenCalledWith(evt);
       }
       faultyCall([null, null, null]);
       faultyCall({});

--- a/test/src/event/events_core_spec.js
+++ b/test/src/event/events_core_spec.js
@@ -76,9 +76,9 @@ describe('events_core.js public API', function() {
         console.warn.calls.reset();
         eventsCore.removeEvent(evt);
         jasmineExpect(console.warn).toHaveBeenCalledWith(
-          'Object does not meet expected event spec',
-          evt
+          'Object does not meet expected event spec'
         );
+        jasmineExpect(console.warn).toHaveBeenCalledWith(evt);
       }
       faultyCall([null, null, null]);
       faultyCall({});

--- a/test/src/template/compiler/compiler_errors_spec.js
+++ b/test/src/template/compiler/compiler_errors_spec.js
@@ -1,0 +1,163 @@
+/**
+ * Tests for compiler_errors.js
+ *
+ * @author    Henry Morgan <hemorgan@wayfair.com>
+ */
+'use strict';
+
+const compilerErrors = require('../../../../src/template/compiler/compiler_errors');
+const compilerLogger = require('../../../../src/template/compiler/compiler_logger');
+
+describe('compiler_errors.js public API', function() {
+  beforeAll(() => {
+    compilerLogger.setStrictMode(false);
+  });
+
+  let overrides = {};
+  beforeEach(() => {
+    overrides.warning = jasmine.createSpy('warn');
+    overrides.exception = jasmine.createSpy('exception');
+    compilerLogger.setOverrides(overrides);
+  });
+
+  describe('warnings', function() {
+    describe('elementIsAVoidElementSoDoesNotNeedAClosingTag', function() {
+      it('should be a function', function() {
+        expect(compilerErrors.elementIsAVoidElementSoDoesNotNeedAClosingTag).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        compilerErrors.elementIsAVoidElementSoDoesNotNeedAClosingTag('test1');
+        jasmineExpect(overrides.warning).toHaveBeenCalledWith(['test1 is a void element so does not need a closing tag'], '');
+      });
+    });
+    describe('cannotPlaceThisTagWithinAPreviousTag', function() {
+      it('should be a function', function() {
+        expect(compilerErrors.cannotPlaceThisTagWithinAPreviousTag).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        compilerErrors.cannotPlaceThisTagWithinAPreviousTag('test1', 'test2', 'test3');
+        jasmineExpect(overrides.warning).toHaveBeenCalledWith(['Cannot place this test1 tag within a test2 tag. test3'], '');
+      });
+    });
+    describe('templateContainsUnclosedItems', function() {
+      it('should be a function', function() {
+        expect(compilerErrors.templateContainsUnclosedItems).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        compilerErrors.templateContainsUnclosedItems({});
+        jasmineExpect(overrides.warning).toHaveBeenCalledWith(['Template contains unclosed items', {}], '');
+      });
+    });
+    describe('mustacheTokenCannotBeInAttributeNames', function() {
+      it('should be a function', function() {
+        expect(compilerErrors.mustacheTokenCannotBeInAttributeNames).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        compilerErrors.mustacheTokenCannotBeInAttributeNames('test');
+        jasmineExpect(overrides.warning).toHaveBeenCalledWith(['Mustache token cannot be in attribute names', 'test'], '');
+      });
+    });
+    describe('doubleCurlyInterpolatorsCannotBeInAttributes', function() {
+      it('should be a function', function() {
+        expect(compilerErrors.doubleCurlyInterpolatorsCannotBeInAttributes).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        compilerErrors.doubleCurlyInterpolatorsCannotBeInAttributes('test');
+        jasmineExpect(overrides.warning).toHaveBeenCalledWith(['Double curly interpolators cannot be in attributes', 'test'], '');
+      });
+    });
+  });
+
+  describe('exceptions', function() {
+    describe('notAllTagsWereClosedProperly', function() {
+      it('should be a function', function() {
+        expect(compilerErrors.notAllTagsWereClosedProperly).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        compilerErrors.notAllTagsWereClosedProperly({});
+        jasmineExpect(overrides.exception).toHaveBeenCalledWith(['Not all tags were closed properly', {}], '');
+      });
+    });
+    describe('wrongClosingElementType', function() {
+      it('should be a function', function() {
+        expect(compilerErrors.wrongClosingElementType).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        compilerErrors.wrongClosingElementType('test1', 'test2');
+        jasmineExpect(overrides.exception).toHaveBeenCalledWith(['</test1> where a </test2> should be'], '');
+      });
+    });
+    describe('closingHTMLElementWithNoPair', function() {
+      it('should be a function', function() {
+        expect(compilerErrors.closingHTMLElementWithNoPair).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        compilerErrors.closingHTMLElementWithNoPair('test');
+        jasmineExpect(overrides.exception).toHaveBeenCalledWith(['</test> with no paired <test>'], '');
+      });
+    });
+    describe('closingMustacheElementWithNoPair', function() {
+      it('should be a function', function() {
+        expect(compilerErrors.closingMustacheElementWithNoPair).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        compilerErrors.closingMustacheElementWithNoPair('test');
+        jasmineExpect(overrides.exception).toHaveBeenCalledWith(['{{/test}} with no paired {{#test}}'], '');
+      });
+    });
+    describe('tagIsClosedBeforeOpenTagIsCompletedCheckForUnpairedQuotes', function() {
+      it('should be a function', function() {
+        expect(compilerErrors.tagIsClosedBeforeOpenTagIsCompletedCheckForUnpairedQuotes).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        compilerErrors.tagIsClosedBeforeOpenTagIsCompletedCheckForUnpairedQuotes();
+        jasmineExpect(overrides.exception).toHaveBeenCalledWith(['Tag is closed before open tag is completed. Check for unpaired quotes'], '');
+      });
+    });
+    describe('differentTagThanExpected', function() {
+      it('should be a function', function() {
+        expect(compilerErrors.differentTagThanExpected).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        compilerErrors.differentTagThanExpected('test1', 'test2');
+        jasmineExpect(overrides.exception).toHaveBeenCalledWith(['test1 where a test2 should be'], '');
+      });
+    });
+  });
+
+  describe('extend', function() {
+    it('should be a function', function() {
+      expect(compilerErrors.extend).to.be.a('function');
+    });
+
+    const customHint = 'test custom hint';
+    const customHint2 = 'test custom hint 2';
+    let originalMessage;
+    it('should extend an error message appropriately', function() {
+      compilerErrors.elementIsAVoidElementSoDoesNotNeedAClosingTag('<input>');
+      originalMessage = overrides.warning.calls.mostRecent().args[0][0];
+      compilerErrors.extend('elementIsAVoidElementSoDoesNotNeedAClosingTag', customHint);
+      compilerErrors.elementIsAVoidElementSoDoesNotNeedAClosingTag('<input>');
+      jasmineExpect(overrides.warning.calls.mostRecent().args[0][0]).toEqual(`${originalMessage}. ${customHint}`);
+    });
+    it('should support multiple extensions of an error message', function() {
+      compilerErrors.extend('elementIsAVoidElementSoDoesNotNeedAClosingTag', customHint2);
+      compilerErrors.elementIsAVoidElementSoDoesNotNeedAClosingTag('<input>');
+      jasmineExpect(overrides.warning.calls.mostRecent().args[0][0]).toEqual(`${originalMessage}. ${customHint}. ${customHint2}`);
+    });
+    it('should reject nonexistent error messages', function() {
+      const nonexistentError = '___thiserrordoesnotexist___';
+      spyOn(compilerLogger, 'warn');
+      compilerErrors.extend(nonexistentError, customHint);
+      jasmineExpect(compilerLogger.warn).toHaveBeenCalledWith(`Tried to extend a nonexistent error message: ${nonexistentError}`);
+    });
+    it('should support extension of an error message that passes multiple arguments to compilerLogger', function() {
+      compilerErrors.notAllTagsWereClosedProperly({});
+      let responseArray = overrides.exception.calls.mostRecent().args[0];
+      responseArray[0] = `${responseArray[0]}. ${customHint}`;
+      compilerErrors.extend('notAllTagsWereClosedProperly', customHint);
+      compilerErrors.notAllTagsWereClosedProperly({});
+      jasmineExpect(overrides.exception.calls.mostRecent().args[0]).toEqual(responseArray);
+    });
+  });
+});

--- a/test/src/utils/errors_spec.js
+++ b/test/src/utils/errors_spec.js
@@ -1,182 +1,184 @@
+/**
+ * Tests for errors.js
+ *
+ * @author    Henry Morgan <hemorgan@wayfair.com>
+ */
 'use strict';
 
 const errors = require('../../../src/utils/errors');
 const logger = require('../../../src/utils/logger');
-const _ = require('underscore');
 
 describe('errors.js public API', function() {
   describe('warnings', function() {
+    beforeEach(function() {
+      spyOn(logger, 'warn');
+    });
     describe('childViewWasPassedAsObjectWithoutAScopeProperty', function() {
-      beforeEach(function() {
-        spyOn(logger, 'warn');
+      it('should be a function', function() {
+        expect(errors.childViewWasPassedAsObjectWithoutAScopeProperty).to.be.a('function');
       });
-      describe('childViewWasPassedAsObjectWithoutAScopeProperty', function() {
-        it('should be a function', function() {
-          expect(errors.childViewWasPassedAsObjectWithoutAScopeProperty).to.be.a('function');
-        });
-        it('should log the correct error message', function() {
-          errors.childViewWasPassedAsObjectWithoutAScopeProperty();
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('ChildView was passed as object without a scope property');
-        });
+      it('should log the correct error message', function() {
+        errors.childViewWasPassedAsObjectWithoutAScopeProperty();
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('ChildView was passed as object without a scope property');
       });
-      describe('collectionMethodMayNotBeOverridden', function() {
-        it('should be a function', function() {
-          expect(errors.collectionMethodMayNotBeOverridden).to.be.a('function');
-        });
-        it('should log the correct error message', function() {
-          let methodName = 'initialize', debugName = 'TestCollection';
-          errors.collectionMethodMayNotBeOverridden(methodName);
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('Collection.initialize may not be overridden');
-          errors.collectionMethodMayNotBeOverridden(methodName, debugName);
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('Collection.initialize may not be overridden for collection "TestCollection"');
-        });
+    });
+    describe('collectionMethodMayNotBeOverridden', function() {
+      it('should be a function', function() {
+        expect(errors.collectionMethodMayNotBeOverridden).to.be.a('function');
       });
-      describe('collectionExpectedArrayOfObjectsButGot', function() {
-        it('should be a function', function() {
-          expect(errors.collectionExpectedArrayOfObjectsButGot).to.be.a('function');
-        });
-        it('should log the correct error message', function() {
-          errors.collectionExpectedArrayOfObjectsButGot('test string');
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('Collection expected array of objects but got: test string');
-        });
+      it('should log the correct error message', function() {
+        let methodName = 'initialize', debugName = 'TestCollection';
+        errors.collectionMethodMayNotBeOverridden(methodName);
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('Collection.initialize may not be overridden');
+        errors.collectionMethodMayNotBeOverridden(methodName, debugName);
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('Collection.initialize may not be overridden for collection "TestCollection"');
       });
-      describe('modelMethodMayNotBeOverridden', function() {
-        it('should be a function', function() {
-          expect(errors.modelMethodMayNotBeOverridden).to.be.a('function');
-        });
-        it('should log the correct error message', function() {
-          let methodName = 'initialize', debugName = 'TestModel';
-          errors.modelMethodMayNotBeOverridden(methodName);
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('Model.initialize may not be overridden');
-          errors.modelMethodMayNotBeOverridden(methodName, debugName);
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('Model.initialize may not be overridden for model "TestModel"');
-        });
+    });
+    describe('collectionExpectedArrayOfObjectsButGot', function() {
+      it('should be a function', function() {
+        expect(errors.collectionExpectedArrayOfObjectsButGot).to.be.a('function');
       });
-      describe('modelExpectedObjectOfAttributesButGot', function() {
-        it('should be a function', function() {
-          expect(errors.modelExpectedObjectOfAttributesButGot).to.be.a('function');
-        });
-        it('should log the correct error message', function() {
-          errors.modelExpectedObjectOfAttributesButGot('test string');
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('Model expected object of attributes but got: test string');
-        });
+      it('should log the correct error message', function() {
+        errors.collectionExpectedArrayOfObjectsButGot('test string');
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('Collection expected array of objects but got: test string');
       });
-      describe('domDoesNotMatchVDOMForView', function() {
-        it('should be a function', function() {
-          expect(errors.domDoesNotMatchVDOMForView).to.be.a('function');
-        });
-        it('should log the correct error message', function() {
-          errors.domDoesNotMatchVDOMForView('TestView');
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('DOM does not match VDOM for view "TestView". Use debug panel to see differences');
-        });
+    });
+    describe('modelMethodMayNotBeOverridden', function() {
+      it('should be a function', function() {
+        expect(errors.modelMethodMayNotBeOverridden).to.be.a('function');
       });
-      describe('viewMethodMayNotBeOverridden', function() {
-        it('should be a function', function() {
-          expect(errors.viewMethodMayNotBeOverridden).to.be.a('function');
-        });
-        it('should log the correct error message', function() {
-          let methodName = 'initialize', debugName = 'TestView';
-          errors.viewMethodMayNotBeOverridden(methodName);
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('View.initialize may not be overridden');
-          errors.viewMethodMayNotBeOverridden(methodName, debugName);
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('View.initialize may not be overridden for view "TestView"');
-        });
+      it('should log the correct error message', function() {
+        let methodName = 'initialize', debugName = 'TestModel';
+        errors.modelMethodMayNotBeOverridden(methodName);
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('Model.initialize may not be overridden');
+        errors.modelMethodMayNotBeOverridden(methodName, debugName);
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('Model.initialize may not be overridden for model "TestModel"');
       });
-      describe('componentFunctionMayNotBeCalledDirectly', function() {
-        it('should be a function', function() {
-          expect(errors.componentFunctionMayNotBeCalledDirectly).to.be.a('function');
-        });
-        it('should log the correct error message', function() {
-          errors.componentFunctionMayNotBeCalledDirectly('initialize');
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('Component.initialize may not be called directly');
-        });
+    });
+    describe('modelExpectedObjectOfAttributesButGot', function() {
+      it('should be a function', function() {
+        expect(errors.modelExpectedObjectOfAttributesButGot).to.be.a('function');
       });
-      describe('cannotOverwriteComponentMethod', function() {
-        it('should be a function', function() {
-          expect(errors.cannotOverwriteComponentMethod).to.be.a('function');
-        });
-        it('should log the correct error message', function() {
-          errors.cannotOverwriteComponentMethod('initialize');
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('Cannot overwrite component method: initialize');
-        });
+      it('should log the correct error message', function() {
+        errors.modelExpectedObjectOfAttributesButGot('test string');
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('Model expected object of attributes but got: test string');
       });
-      describe('unableToParseToAValidValueMustMatchJSONFormat', function() {
-        it('should be a function', function() {
-          expect(errors.unableToParseToAValidValueMustMatchJSONFormat).to.be.a('function');
-        });
-        it('should log the correct error message', function() {
-          errors.unableToParseToAValidValueMustMatchJSONFormat('test value');
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('Unable to parse "test value" to a valid value. Input must match JSON format');
-        });
+    });
+    describe('domDoesNotMatchVDOMForView', function() {
+      it('should be a function', function() {
+        expect(errors.domDoesNotMatchVDOMForView).to.be.a('function');
       });
-      describe('widgetTypeHasNoTemplateToStringFunctionFallingBackToDOM', function() {
-        it('should be a function', function() {
-          expect(errors.widgetTypeHasNoTemplateToStringFunctionFallingBackToDOM).to.be.a('function');
-        });
-        it('should log the correct error message', function() {
-          errors.widgetTypeHasNoTemplateToStringFunctionFallingBackToDOM('TestWidget');
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('Widget type: TestWidget has no templateToString function, falling back to DOM');
-        });
+      it('should log the correct error message', function() {
+        errors.domDoesNotMatchVDOMForView('TestView');
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('DOM does not match VDOM for view "TestView". Use debug panel to see differences');
       });
-      describe('objectDoesNotMeetExpectedEventSpec', function() {
-        it('should be a function', function() {
-          expect(errors.objectDoesNotMeetExpectedEventSpec).to.be.a('function');
-        });
-        it('should log the correct error message', function() {
-          errors.objectDoesNotMeetExpectedEventSpec({});
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('Object does not meet expected event spec', {});
-        });
+    });
+    describe('viewMethodMayNotBeOverridden', function() {
+      it('should be a function', function() {
+        expect(errors.viewMethodMayNotBeOverridden).to.be.a('function');
       });
-      describe('warningNoPartialRegisteredWithTheName', function() {
-        it('should be a function', function() {
-          expect(errors.warningNoPartialRegisteredWithTheName).to.be.a('function');
-        });
-        it('should log the correct error message', function() {
-          errors.warningNoPartialRegisteredWithTheName('TestPartial');
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('Warning: no partial registered with the name TestPartial');
-        });
+      it('should log the correct error message', function() {
+        let methodName = 'initialize', debugName = 'TestView';
+        errors.viewMethodMayNotBeOverridden(methodName);
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('View.initialize may not be overridden');
+        errors.viewMethodMayNotBeOverridden(methodName, debugName);
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('View.initialize may not be overridden for view "TestView"');
       });
-      describe('doubleCurlyInterpolatorsCannotBeInAttributes', function() {
-        it('should be a function', function() {
-          expect(errors.doubleCurlyInterpolatorsCannotBeInAttributes).to.be.a('function');
-        });
-        it('should log the correct error message', function() {
-          errors.doubleCurlyInterpolatorsCannotBeInAttributes();
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('Double curly interpolators cannot be in attributes');
-        });
+    });
+    describe('componentFunctionMayNotBeCalledDirectly', function() {
+      it('should be a function', function() {
+        expect(errors.componentFunctionMayNotBeCalledDirectly).to.be.a('function');
       });
-      describe('tagsImproperlyPairedClosing', function() {
-        it('should be a function', function() {
-          expect(errors.tagsImproperlyPairedClosing).to.be.a('function');
-        });
-        it('should log the correct error message', function() {
-          errors.tagsImproperlyPairedClosing('testDiv', 'testOpenID', 'testCloseID');
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('testDiv tags improperly paired, closing testOpenID with close tag from testCloseID');
-        });
+      it('should log the correct error message', function() {
+        errors.componentFunctionMayNotBeCalledDirectly('initialize');
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('Component.initialize may not be called directly');
       });
-      describe('closingElementWhenTheStackWasEmpty', function() {
-        it('should be a function', function() {
-          expect(errors.closingElementWhenTheStackWasEmpty).to.be.a('function');
-        });
-        it('should log the correct error message', function() {
-          errors.closingElementWhenTheStackWasEmpty('testID');
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('Closing element testID when the stack was empty');
-        });
+    });
+    describe('cannotOverwriteComponentMethod', function() {
+      it('should be a function', function() {
+        expect(errors.cannotOverwriteComponentMethod).to.be.a('function');
       });
-      describe('computedPropertiesAreNowDeprecatedPleaseChange', function() {
-        it('should be a function', function() {
-          expect(errors.computedPropertiesAreNowDeprecatedPleaseChange).to.be.a('function');
-        });
-        it('should log the correct error message', function() {
-          errors.computedPropertiesAreNowDeprecatedPleaseChange('testComputedProp');
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('Computed properties are now deprecated and will be removed soon. Please change "testComputedProp" to a derived property');
-        });
+      it('should log the correct error message', function() {
+        errors.cannotOverwriteComponentMethod('initialize');
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('Cannot overwrite component method: initialize');
+      });
+    });
+    describe('unableToParseToAValidValueMustMatchJSONFormat', function() {
+      it('should be a function', function() {
+        expect(errors.unableToParseToAValidValueMustMatchJSONFormat).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        errors.unableToParseToAValidValueMustMatchJSONFormat('test value');
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('Unable to parse "test value" to a valid value. Input must match JSON format');
+      });
+    });
+    describe('widgetTypeHasNoTemplateToStringFunctionFallingBackToDOM', function() {
+      it('should be a function', function() {
+        expect(errors.widgetTypeHasNoTemplateToStringFunctionFallingBackToDOM).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        errors.widgetTypeHasNoTemplateToStringFunctionFallingBackToDOM('TestWidget');
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('Widget type: TestWidget has no templateToString function, falling back to DOM');
+      });
+    });
+    describe('objectDoesNotMeetExpectedEventSpec', function() {
+      it('should be a function', function() {
+        expect(errors.objectDoesNotMeetExpectedEventSpec).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        errors.objectDoesNotMeetExpectedEventSpec({});
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('Object does not meet expected event spec', {});
+      });
+    });
+    describe('warningNoPartialRegisteredWithTheName', function() {
+      it('should be a function', function() {
+        expect(errors.warningNoPartialRegisteredWithTheName).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        errors.warningNoPartialRegisteredWithTheName('TestPartial');
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('Warning: no partial registered with the name TestPartial');
+      });
+    });
+    describe('doubleCurlyInterpolatorsCannotBeInAttributes', function() {
+      it('should be a function', function() {
+        expect(errors.doubleCurlyInterpolatorsCannotBeInAttributes).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        errors.doubleCurlyInterpolatorsCannotBeInAttributes();
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('Double curly interpolators cannot be in attributes');
+      });
+    });
+    describe('tagsImproperlyPairedClosing', function() {
+      it('should be a function', function() {
+        expect(errors.tagsImproperlyPairedClosing).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        errors.tagsImproperlyPairedClosing('testDiv', 'testOpenID', 'testCloseID');
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('testDiv tags improperly paired, closing testOpenID with close tag from testCloseID');
+      });
+    });
+    describe('closingElementWhenTheStackWasEmpty', function() {
+      it('should be a function', function() {
+        expect(errors.closingElementWhenTheStackWasEmpty).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        errors.closingElementWhenTheStackWasEmpty('testID');
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('Closing element testID when the stack was empty');
+      });
+    });
+    describe('computedPropertiesAreNowDeprecatedPleaseChange', function() {
+      it('should be a function', function() {
+        expect(errors.computedPropertiesAreNowDeprecatedPleaseChange).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        errors.computedPropertiesAreNowDeprecatedPleaseChange('testComputedProp');
+        jasmineExpect(logger.warn).toHaveBeenCalledWith('Computed properties are now deprecated and will be removed soon. Please change "testComputedProp" to a derived property');
       });
     });
   });
 
   describe('errors', function() {
-    beforeAll(function() {
+    beforeEach(function() {
       spyOn(logger, 'error');
     });
     describe('unableToLaunchDebugPanel', function() {
@@ -215,9 +217,9 @@ describe('errors.js public API', function() {
     it('should support extension of an error message that passes multiple arguments to logger', function() {
       let responseArray = errors.objectDoesNotMeetExpectedEventSpec({});
       const extension = 'test extension';
-      responseArray[0] = responseArray[0] + `. ${extension}`;
+      responseArray[0] = `${responseArray[0]}. ${extension}`;
       errors.extend('objectDoesNotMeetExpectedEventSpec', extension);
-      jasmineExpect(_.isEqual(errors.objectDoesNotMeetExpectedEventSpec({}), responseArray)).toEqual(true);
+      jasmineExpect(errors.objectDoesNotMeetExpectedEventSpec({})).toEqual(responseArray);
     });
   });
 });

--- a/test/src/utils/errors_spec.js
+++ b/test/src/utils/errors_spec.js
@@ -4,7 +4,192 @@ const errors = require('../../../src/utils/errors');
 const logger = require('../../../src/utils/logger');
 
 describe('errors.js public API', function() {
-  describe('errors.extend', function() {
+  describe('warnings', function() {
+    describe('childViewWasPassedAsObjectWithoutAScopeProperty', function() {
+      beforeEach(function() {
+        spyOn(logger, 'warn');
+      });
+      describe('childViewWasPassedAsObjectWithoutAScopeProperty', function() {
+        it('should be a function', function() {
+          expect(errors.childViewWasPassedAsObjectWithoutAScopeProperty).to.be.a('function');
+        });
+        it('should log the correct error message', function() {
+          errors.childViewWasPassedAsObjectWithoutAScopeProperty();
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('ChildView was passed as object without a scope property');
+        });
+      });
+      describe('collectionMethodMayNotBeOverridden', function() {
+        it('should be a function', function() {
+          expect(errors.collectionMethodMayNotBeOverridden).to.be.a('function');
+        });
+        it('should log the correct error message', function() {
+          let methodName = 'initialize', debugName = 'TestCollection';
+          errors.collectionMethodMayNotBeOverridden(methodName);
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('Collection.initialize may not be overridden');
+          errors.collectionMethodMayNotBeOverridden(methodName, debugName);
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('Collection.initialize may not be overridden for collection "TestCollection"');
+        });
+      });
+      describe('collectionExpectedArrayOfObjectsButGot', function() {
+        it('should be a function', function() {
+          expect(errors.collectionExpectedArrayOfObjectsButGot).to.be.a('function');
+        });
+        it('should log the correct error message', function() {
+          errors.collectionExpectedArrayOfObjectsButGot('test string');
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('Collection expected array of objects but got: test string');
+        });
+      });
+      describe('modelMethodMayNotBeOverridden', function() {
+        it('should be a function', function() {
+          expect(errors.modelMethodMayNotBeOverridden).to.be.a('function');
+        });
+        it('should log the correct error message', function() {
+          let methodName = 'initialize', debugName = 'TestModel';
+          errors.modelMethodMayNotBeOverridden(methodName);
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('Model.initialize may not be overridden');
+          errors.modelMethodMayNotBeOverridden(methodName, debugName);
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('Model.initialize may not be overridden for model "TestModel"');
+        });
+      });
+      describe('modelExpectedObjectOfAttributesButGot', function() {
+        it('should be a function', function() {
+          expect(errors.modelExpectedObjectOfAttributesButGot).to.be.a('function');
+        });
+        it('should log the correct error message', function() {
+          errors.modelExpectedObjectOfAttributesButGot('test string');
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('Model expected object of attributes but got: test string');
+        });
+      });
+      describe('domDoesNotMatchVDOMForView', function() {
+        it('should be a function', function() {
+          expect(errors.domDoesNotMatchVDOMForView).to.be.a('function');
+        });
+        it('should log the correct error message', function() {
+          errors.domDoesNotMatchVDOMForView('TestView');
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('DOM does not match VDOM for view "TestView". Use debug panel to see differences');
+        });
+      });
+      describe('viewMethodMayNotBeOverridden', function() {
+        it('should be a function', function() {
+          expect(errors.viewMethodMayNotBeOverridden).to.be.a('function');
+        });
+        it('should log the correct error message', function() {
+          let methodName = 'initialize', debugName = 'TestView';
+          errors.viewMethodMayNotBeOverridden(methodName);
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('View.initialize may not be overridden');
+          errors.viewMethodMayNotBeOverridden(methodName, debugName);
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('View.initialize may not be overridden for view "TestView"');
+        });
+      });
+      describe('componentFunctionMayNotBeCalledDirectly', function() {
+        it('should be a function', function() {
+          expect(errors.componentFunctionMayNotBeCalledDirectly).to.be.a('function');
+        });
+        it('should log the correct error message', function() {
+          errors.componentFunctionMayNotBeCalledDirectly('initialize');
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('Component.initialize may not be called directly');
+        });
+      });
+      describe('cannotOverwriteComponentMethod', function() {
+        it('should be a function', function() {
+          expect(errors.cannotOverwriteComponentMethod).to.be.a('function');
+        });
+        it('should log the correct error message', function() {
+          errors.cannotOverwriteComponentMethod('initialize');
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('Cannot overwrite component method: initialize');
+        });
+      });
+      describe('unableToParseToAValidValueMustMatchJSONFormat', function() {
+        it('should be a function', function() {
+          expect(errors.unableToParseToAValidValueMustMatchJSONFormat).to.be.a('function');
+        });
+        it('should log the correct error message', function() {
+          errors.unableToParseToAValidValueMustMatchJSONFormat('test value');
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('Unable to parse "test value" to a valid value. Input must match JSON format');
+        });
+      });
+      describe('widgetTypeHasNoTemplateToStringFunctionFallingBackToDOM', function() {
+        it('should be a function', function() {
+          expect(errors.widgetTypeHasNoTemplateToStringFunctionFallingBackToDOM).to.be.a('function');
+        });
+        it('should log the correct error message', function() {
+          errors.widgetTypeHasNoTemplateToStringFunctionFallingBackToDOM('TestWidget');
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('Widget type: TestWidget has no templateToString function, falling back to DOM');
+        });
+      });
+      describe('objectDoesNotMeetExpectedEventSpec', function() {
+        it('should be a function', function() {
+          expect(errors.objectDoesNotMeetExpectedEventSpec).to.be.a('function');
+        });
+        it('should log the correct error message', function() {
+          errors.objectDoesNotMeetExpectedEventSpec();
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('Object does not meet expected event spec');
+        });
+      });
+      describe('warningNoPartialRegisteredWithTheName', function() {
+        it('should be a function', function() {
+          expect(errors.warningNoPartialRegisteredWithTheName).to.be.a('function');
+        });
+        it('should log the correct error message', function() {
+          errors.warningNoPartialRegisteredWithTheName('TestPartial');
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('Warning: no partial registered with the name TestPartial');
+        });
+      });
+      describe('doubleCurlyInterpolatorsCannotBeInAttributes', function() {
+        it('should be a function', function() {
+          expect(errors.doubleCurlyInterpolatorsCannotBeInAttributes).to.be.a('function');
+        });
+        it('should log the correct error message', function() {
+          errors.doubleCurlyInterpolatorsCannotBeInAttributes();
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('Double curly interpolators cannot be in attributes');
+        });
+      });
+      describe('tagsImproperlyPairedClosing', function() {
+        it('should be a function', function() {
+          expect(errors.tagsImproperlyPairedClosing).to.be.a('function');
+        });
+        it('should log the correct error message', function() {
+          errors.tagsImproperlyPairedClosing('testDiv', 'testOpenID', 'testCloseID');
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('testDiv tags improperly paired, closing testOpenID with close tag from testCloseID');
+        });
+      });
+      describe('closingElementWhenTheStackWasEmpty', function() {
+        it('should be a function', function() {
+          expect(errors.closingElementWhenTheStackWasEmpty).to.be.a('function');
+        });
+        it('should log the correct error message', function() {
+          errors.closingElementWhenTheStackWasEmpty('testID');
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('Closing element testID when the stack was empty');
+        });
+      });
+      describe('computedPropertiesAreNowDeprecatedPleaseChange', function() {
+        it('should be a function', function() {
+          expect(errors.computedPropertiesAreNowDeprecatedPleaseChange).to.be.a('function');
+        });
+        it('should log the correct error message', function() {
+          errors.computedPropertiesAreNowDeprecatedPleaseChange('testComputedProp');
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('Computed properties are now deprecated and will be removed soon. Please change "testComputedProp" to a derived property');
+        });
+      });
+    });
+  });
+
+  describe('errors', function() {
+    beforeAll(function() {
+      spyOn(logger, 'error');
+    });
+    describe('unableToLaunchDebugPanel', function() {
+      it('should be a function', function() {
+        expect(errors.unableToLaunchDebugPanel).to.be.a('function');
+      });
+      it('should log the correct error message', function() {
+        errors.unableToLaunchDebugPanel();
+        jasmineExpect(logger.error).toHaveBeenCalledWith('Unable to launch debug panel. You may need to allow the popup or run "window.launchDebugger()" from your console');
+      });
+    });
+  });
+
+  describe('extend', function() {
     it('should be a function', function() {
       expect(errors.extend).to.be.a('function');
     });

--- a/test/src/utils/errors_spec.js
+++ b/test/src/utils/errors_spec.js
@@ -2,6 +2,7 @@
 
 const errors = require('../../../src/utils/errors');
 const logger = require('../../../src/utils/logger');
+const _ = require('underscore');
 
 describe('errors.js public API', function() {
   describe('warnings', function() {
@@ -122,8 +123,8 @@ describe('errors.js public API', function() {
           expect(errors.objectDoesNotMeetExpectedEventSpec).to.be.a('function');
         });
         it('should log the correct error message', function() {
-          errors.objectDoesNotMeetExpectedEventSpec();
-          jasmineExpect(logger.warn).toHaveBeenCalledWith('Object does not meet expected event spec');
+          errors.objectDoesNotMeetExpectedEventSpec({});
+          jasmineExpect(logger.warn).toHaveBeenCalledWith('Object does not meet expected event spec', {});
         });
       });
       describe('warningNoPartialRegisteredWithTheName', function() {
@@ -210,6 +211,13 @@ describe('errors.js public API', function() {
       spyOn(logger, 'warn');
       errors.extend(nonexistentError, customHint);
       jasmineExpect(logger.warn).toHaveBeenCalledWith(`Tried to extend a nonexistent error message: ${nonexistentError}`);
+    });
+    it('should support extension of an error message that passes multiple arguments to logger', function() {
+      let responseArray = errors.objectDoesNotMeetExpectedEventSpec({});
+      const extension = 'test extension';
+      responseArray[0] = responseArray[0] + `. ${extension}`;
+      errors.extend('objectDoesNotMeetExpectedEventSpec', extension);
+      jasmineExpect(_.isEqual(errors.objectDoesNotMeetExpectedEventSpec({}), responseArray)).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
# Overview

Refactor of the errors module so that error functions call logger directly rather than returning a message.
