### PR TITLE
Template compiler fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ndreckshage/tungstenjs",
+  "name": "tungstenjs",
   "version": "0.14.0",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "tungstenjs",
-  "version": "0.13.5",
+  "name": "@ndreckshage/tungstenjs",
+  "version": "0.14.0",
   "description": "A modular framework for creating web UIs with high-performance rendering on both server and client.",
   "author": "Matt DeGennaro <mdegennaro@wayfair.com>",
   "license": "Apache-2.0",

--- a/precompile/tungsten_template/index.js
+++ b/precompile/tungsten_template/index.js
@@ -10,7 +10,6 @@
  */
 'use strict';
 
-var path = require('path');
 var _ = require('underscore');
 var compiler = require('../../src/template/compiler');
 
@@ -21,9 +20,6 @@ var compiler = require('../../src/template/compiler');
 module.exports = function(contents) {
   this.cacheable();
   var templateData = compiler(contents);
-
-  var templatePath = path.relative(path.dirname(module.dest), __dirname + '/template');
-  templatePath = templatePath.replace(/\\/g, '/');
 
   var output = 'var Template=require("tungstenjs").Template;';
   output += 'var template=new Template(' + JSON.stringify(templateData.templateObj) + ');';

--- a/test/bump-tag.js
+++ b/test/bump-tag.js
@@ -121,12 +121,11 @@ function final(error, match) {
             });
           },
           function writeJson(package, callback) {
-            package.files = ['dist'];
             fs.writeFile(packagePath, JSON.stringify(package, null, 2), function(error) {
               if (error) {
                 callback(error);
               } else {
-                prettyLog.success('Successfully added [files] attribute to package.json');
+                prettyLog.success('Successfully updated package.json');
               }
             });
           }


### PR DESCRIPTION
# Overview

The compiler seems to break for me because `module.dest` undefined, but `templatePath`  not referenced anyways?

Additionally, only the `dist` folder is in npm install. Build scripts adds `files` arr to package.json before publish, acting as a more restrictive npmignore

Needed to get redux adaptor working https://github.com/HumbleSpark/tungsten-redux-adaptor