### PR TITLE
Attribute hook fix

### DIFF
--- a/src/template/process_properties.js
+++ b/src/template/process_properties.js
@@ -135,10 +135,8 @@ module.exports = function processProperties(properties, options) {
     var transformedName = transformPropertyName(lowerPropName);
 
     if (opts.useHooks && typeof opts.useHooks[lowerPropName] === 'function') {
-      propValue = opts.useHooks[lowerPropName](propValue);
-    }
-
-    if (transformedName === false) {
+      result[lowerPropName] = opts.useHooks[lowerPropName](propValue);
+    } else if (transformedName === false) {
       if (!result.attributes) {
         result.attributes = {};
       }

--- a/test/src/template/process_properties_spec.js
+++ b/test/src/template/process_properties_spec.js
@@ -25,7 +25,7 @@ describe('process_properties.js public API', function() {
         }
       });
       jasmineExpect(autofocusSpy).toHaveBeenCalledWith(value);
-      expect(result.attributes.Autofocus).to.equal(hook);
+      expect(result.autofocus).to.equal(hook);
     });
     it('should transform attribute names to property names when appropriate', function() {
       var result = processProperties({class: 'js-test'});


### PR DESCRIPTION
# Overview

Hooks set on attributes were being set on the `attributes` sub-property and handled by `getAttribute` rather than the hook mechanism. This changes it so that if a hook is matched against, it is set to the properties object with no further processing