### PR TITLE
Export render queue to support creating adaptors

### DIFF
--- a/adaptors/shared/common_exports.js
+++ b/adaptors/shared/common_exports.js
@@ -24,5 +24,6 @@ module.exports = {
   _Context: Context,
   addEventPlugin: tungsten.addEventPlugin,
   registerLambda: Context.registerLambda,
-  registerWidget: Template.registerWidget
+  registerWidget: Template.registerWidget,
+  renderQueue: require('./render_queue')
 };


### PR DESCRIPTION
renderQueue is required for creating view adaptors (for example used https://github.com/wayfair/tungstenjs/blob/master/adaptors/backbone/base_view.js#L14).  Export as an API so an external adaptor can use it as well.