### PR TITLE
Downgrade the error message for a Component.on call to an info

### DIFF
--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -112,3 +112,12 @@ for (let type in messages) {
   }
 }
 
+// Temporarily downgrading this error message to an info in the case of 'on'
+module.exports.componentFunctionMayNotBeCalledDirectly = function(fn) {
+  if (fn === 'on') {
+    logger.info('Component.on may not be called directly');
+  } else {
+    logger.warn('Component.' + fn + ' may not be called directly');
+  }
+};
+

--- a/test/src/utils/errors_spec.js
+++ b/test/src/utils/errors_spec.js
@@ -12,6 +12,7 @@ describe('errors.js public API', function() {
   describe('warnings', function() {
     beforeEach(function() {
       spyOn(logger, 'warn');
+      spyOn(logger, 'info');
     });
     describe('childViewWasPassedAsObjectWithoutAScopeProperty', function() {
       it('should be a function', function() {
@@ -92,6 +93,9 @@ describe('errors.js public API', function() {
       it('should log the correct error message', function() {
         errors.componentFunctionMayNotBeCalledDirectly('initialize');
         jasmineExpect(logger.warn).toHaveBeenCalledWith('Component.initialize may not be called directly');
+        // Test for temporarily downgraded error message
+        errors.componentFunctionMayNotBeCalledDirectly('on');
+        jasmineExpect(logger.info).toHaveBeenCalledWith('Component.on may not be called directly');
       });
     });
     describe('cannotOverwriteComponentMethod', function() {


### PR DESCRIPTION
# Overview

Temporarily downgrading an error message in the case of Component.on, while we work on a patch for an issue. (This downgrade is broken by any extension of componentFunctionMayNotBeCalledDirectly, as extending the message will extend the original warning and overwrite the downgraded version.)

