### PR TITLE
Input type hook (for legacy browsers)

### DIFF
--- a/examples/base_webpack.config.js
+++ b/examples/base_webpack.config.js
@@ -1,4 +1,6 @@
 /* eslint-env node */
+'use strict';
+
 var path = require('path');
 
 module.exports = function (root, options) {
@@ -26,14 +28,11 @@ module.exports = function (root, options) {
         'tungstenjs': path.join(__dirname, tungstenPath)
       }
     },
-    resolveLoader: {
-      modules: [path.join(root, 'node_modules')]
-    },
     module: {
-      loaders: [{
-        test: /\.mustache$/,
-        loader: path.join(__dirname, '../precompile/tungsten_template')
-      }]
+      loaders: [
+        {test: /\.mustache$/, loader: path.join(__dirname, '../precompile/tungsten_template')},
+        {test: /\.js$/, loader: 'babel', exclude: /node_modules/}
+      ]
     }
   };
 };

--- a/examples/examples_server.js
+++ b/examples/examples_server.js
@@ -1,3 +1,6 @@
+/* eslint-env node */
+/* eslint-disable no-console */
+
 /**
  * Simple express server for static files
  * Serves to localhost:8000

--- a/examples/input_hook/index.html
+++ b/examples/input_hook/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Input Type Hook Example</title>
+</head>
+<body>
+<div id="appwrapper"></div>
+<script src="js/app.js"></script>
+</body>
+</html>

--- a/examples/input_hook/js/app.js
+++ b/examples/input_hook/js/app.js
@@ -30,7 +30,7 @@ let AppView = View.extend({
         attributes: true
       });
     }
-    this.model.setBrowser(featureDetect.isIE() ? 'IE' : 'Webkit');
+    this.model.setBrowser(featureDetect.isIE() ? 'IE' : 'Not IE');
   },
   postRender: function() {
     // if MutationObserver is not used, get input's type attribute value after

--- a/examples/input_hook/js/app.js
+++ b/examples/input_hook/js/app.js
@@ -1,0 +1,66 @@
+/* eslint-env browser */
+
+'use strict';
+
+const TungstenBackboneBase = require('tungstenjs');
+const View = TungstenBackboneBase.View;
+const Model = TungstenBackboneBase.Model;
+const template = require('../templates/app_view.mustache');
+const featureDetect = require('../../../src/utils/feature_detect');
+let mutationObserved;
+
+let AppView = View.extend({
+  events: {
+    'input .js-inputType': function(e) {
+      this.model.changeNewType(e.currentTarget.value);
+    }
+  },
+  postInitialize: function() {
+    // IE 11+ or webkit browsers - use MutationObserver
+    if (window.MutationObserver) {
+      // using mutationObserve
+      mutationObserved = true;
+      const inputNode = this.el.getElementsByClassName('highlight')[0];
+      const observer = new MutationObserver(
+        mutations => mutations.forEach(
+          mutation => this.model.changeActualType(mutation.target.getAttribute('type') || 'not set')
+        )
+      );
+      observer.observe(inputNode, {
+        attributes: true
+      });
+    }
+    this.model.setBrowser(featureDetect.isIE() ? 'IE' : 'Webkit');
+  },
+  postRender: function() {
+    // if MutationObserver is not used, get input's type attribute value after
+    // DOM was rendered
+    if (!mutationObserved) {
+      let inputNode = this.el.getElementsByClassName('highlight')[0];
+      this.model.changeActualType(inputNode.getAttribute('type') || 'not set');
+    }
+  }
+});
+
+let AppModel = Model.extend({
+  defaults: {
+    newType: 'text',
+    actualType: 'text'
+  },
+  changeNewType: function(newType) {
+    this.set('newType', newType);
+  },
+  changeActualType: function(actualType) {
+    this.set('actualType', actualType);
+  },
+  setBrowser: function(value) {
+    this.set('browser', value);
+  }
+});
+
+window.app = module.exports = new AppView({
+  el: document.getElementById('appwrapper'),
+  template: template,
+  model: new AppModel(),
+  dynamicInitialize: true
+});

--- a/examples/input_hook/package.json
+++ b/examples/input_hook/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "input_hook_example",
+  "version": "0.0.1",
+  "private": true,
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "node ../../node_modules/webpack/bin/webpack.js -d",
+    "start": "node ../examples_server.js --example=input_hook"
+  }
+}

--- a/examples/input_hook/readme.md
+++ b/examples/input_hook/readme.md
@@ -1,6 +1,6 @@
 ## Internet Explorer type attribute hooks for `Input` element.
 
-Internet Explorer doesn't adhere to the standard when setting not supported input types, and not falling back to `type="text"`.<br>
+Internet Explorer doesn't adhere to the standard when setting unsupported input types and does not fall back to `type="text"`.<br>
 This example will allow setting only supported types for Internet Explorer and falling back to `type="text"`, if type is not supported.
 
 ## Run

--- a/examples/input_hook/readme.md
+++ b/examples/input_hook/readme.md
@@ -1,0 +1,13 @@
+## Internet Explorer type attribute hooks for `Input` element.
+
+Internet Explorer doesn't adhere to the standard when setting not supported input types, and not falling back to `type="text"`.<br>
+This example will allow setting only supported types for Internet Explorer and falling back to `type="text"`, if type is not supported.
+
+## Run
+
+```
+# run `npm install && npm run dist` on the main tungstenjs directory
+npm install
+npm start
+# To run in debug mode: `npm start -- --dev`
+```

--- a/examples/input_hook/templates/app_view.mustache
+++ b/examples/input_hook/templates/app_view.mustache
@@ -1,0 +1,6 @@
+<h2>Input Type Hooks</h2>
+<label for="inputType">Change input's type to</label>
+<input type="text" id="inputType" name="inputType" class="js-inputType" placeholder="anything"> !
+<br><br>
+<label for="input"><span>[{{browser}}]</span> Input type is <span>{{actualType}}</span>.</label>
+<input type="{{newType}}" name="input" class="highlight" value="123 abc !@# xyz">

--- a/examples/input_hook/templates/app_view.mustache
+++ b/examples/input_hook/templates/app_view.mustache
@@ -1,5 +1,5 @@
 <h2>Input Type Hooks</h2>
-<label for="inputType">Change input's type to</label>
+<label for="inputType">Change input type to</label>
 <input type="text" id="inputType" name="inputType" class="js-inputType" placeholder="anything"> !
 <br><br>
 <label for="input"><span>[{{browser}}]</span> Input type is <span>{{actualType}}</span>.</label>

--- a/examples/input_hook/templates/index.mustache
+++ b/examples/input_hook/templates/index.mustache
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Input Type Hook Example</title>
+    <style media="screen">
+      .highlight {
+        border-color: #9400d3;
+        border-radius: 10px;
+        width: 200px;
+      }
+      span {
+        font-weight: bold;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="appwrapper">{{> app_view }}</div>
+    <script src="js/app.min.js"></script>
+  </body>
+</html>

--- a/examples/input_hook/webpack.config.js
+++ b/examples/input_hook/webpack.config.js
@@ -1,0 +1,5 @@
+/* eslint-env node */
+
+module.exports = function(options) {
+  return require('../base_webpack.config.js')(__dirname, options);
+};

--- a/precompile/tungsten_template/index.js
+++ b/precompile/tungsten_template/index.js
@@ -10,7 +10,6 @@
  */
 'use strict';
 
-var path = require('path');
 var _ = require('underscore');
 var compiler = require('../../src/template/compiler');
 
@@ -21,9 +20,6 @@ var compiler = require('../../src/template/compiler');
 module.exports = function(contents) {
   this.cacheable();
   var templateData = compiler(contents);
-
-  var templatePath = path.relative(path.dirname(module.dest), __dirname + '/template');
-  templatePath = templatePath.replace(/\\/g, '/');
 
   var output = 'var Template=require("tungstenjs").Template;';
   output += 'var template=new Template(' + JSON.stringify(templateData.templateObj) + ');';

--- a/src/template/hooks/input_type.js
+++ b/src/template/hooks/input_type.js
@@ -1,0 +1,57 @@
+/* eslint-env browser */
+
+/**
+ * Hook for Virtual-Dom library to prevent setting unsupported input types in IE
+ *
+ * @author Artem Ruts <aruts@wayfair.com>
+ * @copyright 2016 Wayfair LLC - All rights reserved
+ */
+
+'use strict';
+
+// possible input types according to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
+const possibleTypes = ['button', 'checkbox', 'color', 'date', 'datetime',
+  'datetime-local', 'email', 'file', 'hidden', 'image', 'month', 'number',
+  'password', 'radio', 'range', 'reset', 'search', 'submit', 'tel', 'text',
+  'time', 'url', 'week'];
+
+// test for supported input types
+let input = document.createElement('input');
+const allowedTypes = possibleTypes.filter(function(type) {
+  try {
+    input.type = type;
+    return true;
+  } catch (ex) {
+    return false;
+  }
+});
+
+function InputTypeHook(newType) {
+  if (!(this instanceof InputTypeHook)) {
+    return new InputTypeHook(newType);
+  } else {
+    this.newType = newType;
+  }
+}
+
+InputTypeHook.prototype.hook = function(node, prop) {
+  // don't do anything if type didn't change
+  if (node.type === this.newType) {
+    return;
+  }
+
+  const TAG_NAME = 'INPUT';
+  // if input type is not supported - fallback to type "text"
+  if (node.tagName === TAG_NAME ||
+      node.nodeName === TAG_NAME ||
+      node.constructor.name === 'HTMLInputElement') {
+    if (allowedTypes.indexOf(this.newType) === -1) {
+      this.newType = 'text';
+    }
+  }
+
+  node[prop] = this.newType;
+};
+
+InputTypeHook.prototype.type = 'InputTypeHook';
+module.exports = InputTypeHook;

--- a/src/template/stacks/vdom.js
+++ b/src/template/stacks/vdom.js
@@ -5,13 +5,20 @@ var HTMLCommentWidget = require('../widgets/html_comment');
 var htmlParser = require('../html_parser');
 var DefaultStack = require('./default');
 var Autofocus = require('../hooks/autofocus');
+var InputType = require('../hooks/input_type');
+var featureDetect = require('../../utils/feature_detect');
 
 function VdomStack(attributesOnly, debugMode) {
   DefaultStack.call(this, attributesOnly, debugMode);
   // Override default property
   this.propertyOpts.useHooks = {
-    'autofocus': Autofocus
+    autofocus: Autofocus
   };
+
+  // if browser is IE - add [type] attribute hook for Input elements
+  if (featureDetect.isIE()) {
+    this.propertyOpts.useHooks.type = InputType;
+  }
 }
 VdomStack.prototype = new DefaultStack();
 VdomStack.prototype.constructor = VdomStack;

--- a/src/utils/feature_detect.js
+++ b/src/utils/feature_detect.js
@@ -11,5 +11,11 @@ module.exports = {
       return false;
     }
     return /iPhone|iPad|iPod/i.test(window.navigator.userAgent);
+  },
+  isIE: function() {
+    if (!window.navigator) {
+      return false;
+    }
+    return /Edge\/|Trident\/|MSIE/i.test(window.navigator.userAgent);
   }
 };

--- a/test/src/template/hooks/input_type_spec.js
+++ b/test/src/template/hooks/input_type_spec.js
@@ -34,7 +34,7 @@ describe('input_type.js', function() {
             // default type value
             value: 'text',
             setCount: 0,
-            getCallsCount: 0,
+            getCount: 0,
             calledWith: []
           },
           writable: true
@@ -46,7 +46,7 @@ describe('input_type.js', function() {
         'type': {
           enumerable: true,
           get: function() {
-            this.calls.getCallsCount++;
+            this.calls.getCount++;
             return this.calls.value;
           },
           set: function(newType) {

--- a/test/src/template/hooks/input_type_spec.js
+++ b/test/src/template/hooks/input_type_spec.js
@@ -64,14 +64,14 @@ describe('input_type.js', function() {
     });
 
     it('should fallback to "text" type', function() {
-      // instantiate a hook with not supported input type
+      // instantiate a hook with unsupported input type
       var hook = InputTypeHook('calendar');
       // tell hook to look for [type] attribute
       hook.hook(this.mockInput, 'type');
 
-      // expect input's type to fallback to "text"
+      // expect input type to fall back to "text"
       expect(this.mockInput.type).to.equal('text');
-      // expect one assigment with "text" value
+      // expect one assignment with "text" value
       expect(this.mockInput.calls.setCount).to.equal(1);
       expect(this.mockInput.calls.calledWith).to.deep.equal(['text']);
     });
@@ -82,9 +82,9 @@ describe('input_type.js', function() {
       // tell hook to look for [type] attribute
       hook.hook(this.mockInput, 'type');
 
-      // expect input's type to fallback to "text"
+      // expect input type to fall back to "text"
       expect(this.mockInput.type).to.equal('file');
-      // expect one assigment with "file" value
+      // expect one assignment with "file" value
       expect(this.mockInput.calls.setCount).to.equal(1);
       expect(this.mockInput.calls.calledWith).to.deep.equal(['file']);
     });
@@ -95,9 +95,9 @@ describe('input_type.js', function() {
       // tell hook to look for [type] attribute
       hook.hook(this.mockInput, 'type');
 
-      // expect input's type to stay "text"
+      // expect input type to stay "text"
       expect(this.mockInput.type).to.equal('text');
-      // expect no type assigments
+      // expect no type assignments
       expect(this.mockInput.calls.setCount).to.equal(0);
       expect(this.mockInput.calls.calledWith).to.be.empty;
     });

--- a/test/src/template/hooks/input_type_spec.js
+++ b/test/src/template/hooks/input_type_spec.js
@@ -1,0 +1,105 @@
+/* eslint-disable new-cap */
+'use strict';
+
+var InputTypeHook = require('../../../../src/template/hooks/input_type.js');
+
+describe('input_type.js', function() {
+
+  it('should be a function', function() {
+    expect(InputTypeHook).to.be.a('function');
+    expect(InputTypeHook).to.have.length(1);
+  });
+
+  it('should have', function() {
+    expect(InputTypeHook.prototype.type).to.equal('InputTypeHook');
+  });
+
+  describe('constructor', function() {
+    it('constructs with new', function() {
+      var hook = new InputTypeHook();
+      expect(hook).to.be.instanceof(InputTypeHook);
+    });
+    it('constructs without new', function() {
+      var hook = InputTypeHook();
+      expect(hook).to.be.instanceof(InputTypeHook);
+    });
+  });
+
+  describe('hook', function() {
+    beforeEach(function() {
+      // Input mock with some call tracking
+      this.mockInput = Object.defineProperties({}, {
+        'calls': {
+          value: {
+            // default type value
+            value: 'text',
+            setCount: 0,
+            getCallsCount: 0,
+            calledWith: []
+          },
+          writable: true
+        },
+        'tagName': {
+          value: 'INPUT',
+          enumerable: true
+        },
+        'type': {
+          enumerable: true,
+          get: function() {
+            this.calls.getCallsCount++;
+            return this.calls.value;
+          },
+          set: function(newType) {
+            this.calls.setCount++;
+            this.calls.calledWith.push(newType);
+            this.calls.value = newType;
+          }
+        }
+      });
+    });
+
+    it('should be a function', function() {
+      expect(InputTypeHook.prototype.hook).to.be.a('function');
+      expect(InputTypeHook.prototype.hook).to.have.length(2);
+    });
+
+    it('should fallback to "text" type', function() {
+      // instantiate a hook with not supported input type
+      var hook = InputTypeHook('calendar');
+      // tell hook to look for [type] attribute
+      hook.hook(this.mockInput, 'type');
+
+      // expect input's type to fallback to "text"
+      expect(this.mockInput.type).to.equal('text');
+      // expect one assigment with "text" value
+      expect(this.mockInput.calls.setCount).to.equal(1);
+      expect(this.mockInput.calls.calledWith).to.deep.equal(['text']);
+    });
+
+    it('should not fallback to "text" type', function() {
+      // instantiate a hook with supported input type
+      var hook = InputTypeHook('file');
+      // tell hook to look for [type] attribute
+      hook.hook(this.mockInput, 'type');
+
+      // expect input's type to fallback to "text"
+      expect(this.mockInput.type).to.equal('file');
+      // expect one assigment with "file" value
+      expect(this.mockInput.calls.setCount).to.equal(1);
+      expect(this.mockInput.calls.calledWith).to.deep.equal(['file']);
+    });
+
+    it('should not do anything', function() {
+      // instantiate a hook with default input type
+      var hook = InputTypeHook('text');
+      // tell hook to look for [type] attribute
+      hook.hook(this.mockInput, 'type');
+
+      // expect input's type to stay "text"
+      expect(this.mockInput.type).to.equal('text');
+      // expect no type assigments
+      expect(this.mockInput.calls.setCount).to.equal(0);
+      expect(this.mockInput.calls.calledWith).to.be.empty;
+    });
+  });
+});

--- a/test/src/template/hooks/input_type_spec.js
+++ b/test/src/template/hooks/input_type_spec.js
@@ -10,7 +10,7 @@ describe('input_type.js', function() {
     expect(InputTypeHook).to.have.length(1);
   });
 
-  it('should have', function() {
+  it('should have correct type', function() {
     expect(InputTypeHook.prototype.type).to.equal('InputTypeHook');
   });
 

--- a/test/src/utils/feature_detect_spec.js
+++ b/test/src/utils/feature_detect_spec.js
@@ -17,7 +17,6 @@ describe('feature_detect.js public API', function() {
     it('should be a function', function() {
       expect(featureDetect.isiOS).to.be.a('function');
     });
-
     it('should not fail if navigator is not present', function() {
       window.navigator = null;
       expect(featureDetect.isiOS()).to.be.false;
@@ -40,19 +39,105 @@ describe('feature_detect.js public API', function() {
       };
       expect(featureDetect.isiOS()).to.be.true;
     });
-
     it('should negatively identify Android', function() {
       window.navigator = {
         userAgent: 'Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.65 Mobile Safari/537.36'
       };
       expect(featureDetect.isiOS()).to.be.false;
     });
-
     it('should negatively identify IE', function() {
       window.navigator = {
         userAgent: 'Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; GTB7.4; InfoPath.2; SV1; .NET CLR 3.3.69573; WOW64; en-US)'
       };
       expect(featureDetect.isiOS()).to.be.false;
+    });
+  });
+
+  describe('isIE', function() {
+    it('should be a function', function() {
+      expect(featureDetect.isIE).to.be.a('function');
+    });
+    it('should not fail if navigator is not present', function() {
+      window.navigator = null;
+      expect(featureDetect.isIE()).to.be.false;
+    });
+    it('should positively identify IE8', function() {
+      window.navigator = {
+        userAgent: 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Win64; x64; Trident/4.0)'
+      };
+      expect(featureDetect.isIE()).to.be.true;
+    });
+    it('should positively identify IE 9', function() {
+      window.navigator = {
+        userAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; Trident/5.0)'
+      };
+      expect(featureDetect.isIE()).to.be.true;
+    });
+    it('should positively identify IE 10', function() {
+      window.navigator = {
+        userAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)'
+      };
+      expect(featureDetect.isIE()).to.be.true;
+    });
+    it('should positively identify IE 11', function() {
+      window.navigator = {
+        userAgent: 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko'
+      };
+      expect(featureDetect.isIE()).to.be.true;
+    });
+    it('should positively identify IE Edge', function() {
+      window.navigator = {
+        userAgent: 'Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10136'
+      };
+      expect(featureDetect.isIE()).to.be.true;
+    });
+    it('should negatively identify Safari 8', function() {
+      window.navigator = {
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12'
+      };
+      expect(featureDetect.isIE()).to.be.false;
+    });
+    it('should negatively identify Yandex Browser', function() {
+      window.navigator = {
+        userAgent: 'Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.172 YaBrowser/1.7.1364.22194 Safari/537.22'
+      };
+      expect(featureDetect.isIE()).to.be.false;
+    });
+    it('should negatively identify SeaMonkey', function() {
+      window.navigator = {
+        userAgent: 'Mozilla/5.0 (X11; Linux i686; rv:10.0.1) Gecko/20100101 Firefox/10.0.1 SeaMonkey/2.7.1'
+      };
+      expect(featureDetect.isIE()).to.be.false;
+    });
+    it('should negatively identify Firefox', function() {
+      window.navigator = {
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:49.0) Gecko/20100101 Firefox/49.0'
+      };
+      expect(featureDetect.isIE()).to.be.false;
+    });
+    it('should negatively identify Android', function() {
+      window.navigator = {
+        userAgent: 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 6P Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36'
+      };
+      expect(featureDetect.isIE()).to.be.false;
+    });
+    it('should negatively identify Amazon Fire TV', function() {
+      window.navigator = {
+        userAgent: 'Mozilla/5.0 (Linux; Android 4.2.2; AFTB Build/JDQ39) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.173 Mobile Safari/537.22'
+      };
+      expect(featureDetect.isIE()).to.be.false;
+    });
+    it('should negatively identify Amazon Kindle 4', function() {
+      window.navigator = {
+        userAgent: 'Mozilla/5.0 (X11; U; Linux armv7l like Android; en-us) AppleWebKit/531.2+ (KHTML, like Gecko) Version/5.0 Safari/533.2+ Kindle/3.0+'
+      };
+      expect(featureDetect.isIE()).to.be.false;
+    });
+    it('should negatively identify Chrome Desktop', function() {
+      window.navigator = {
+        userAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.36'
+      };
+      expect(featureDetect.isIE()).to.be.false;
     });
   });
 });

--- a/webpack-helper.js
+++ b/webpack-helper.js
@@ -1,5 +1,7 @@
+/* eslint-env node */
+
 'use strict';
-/* global process, __dirname */
+
 var path = require('path');
 var webpack = require('webpack');
 function ensureLoader(loaders, test, loader) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 var webpack = require('webpack');
 var path = require('path');
 
@@ -33,14 +35,10 @@ module.exports = function(options) {
     ],
     module: {
       loaders: [
-        {
-          test: /\.js$/,
-          loader: 'babel',
-          exclude: /node_modules/
-        },
+        {test: /\.js$/, loader: 'babel', exclude: /node_modules/},
         {test: /\.mustache$/, loader: 'tungsten_template'},
         {test: /\.json$/, loader: 'json-loader'}
       ]
     }
-  }
+  };
 };

--- a/webpack.plugins.js
+++ b/webpack.plugins.js
@@ -1,8 +1,10 @@
+/* eslint-env node */
+
 /*
  * Package plugins in UMD modules.
  */
 
-/* global __dirname */
+'use strict';
 
 var webpackSettings = require('./webpack-helper');
 

--- a/webpack.standalone.js
+++ b/webpack.standalone.js
@@ -1,4 +1,7 @@
-var webpack = require('webpack');
+/* eslint-env node */
+
+'use strict';
+
 var webpackSettings = require('./webpack-helper');
 var path = require('path');
 
@@ -31,5 +34,5 @@ module.exports = function(options) {
     module: {
       loaders: []
     }
-  }, options.dev, options.test)
+  }, options.dev, options.test);
 };


### PR DESCRIPTION
# Overview

Internet Explorer doesn't adhere to the standard when setting unsupported input types and does not fall back to `type="text"`.<br>

## Details

**Input type hook** will test for all supported input types and allow setting only supported ones. It will manually set type to `"text"`, if input type is unsupported. Hook will be enabled only for Internet Explorer.

## Tested on

* Internet Explorer 9 on Windows 7
* Internet Explorer 10 on Windows 8
* Internet Explorer 11 on Windows 8.1
* Internet Explorer Edge on Windows 10
* Chrome 52 on OSX El Captain
* Safari 9.1.1 on OSX El Captain
* Firefox 50.0a2 on OSX El Captain

Example is included for testing purposes, it's easy to test how hook works with it.
