### PR TITLE
Removing list from property list so it is handled by setAttribute

### DIFF
--- a/src/template/process_properties.js
+++ b/src/template/process_properties.js
@@ -27,7 +27,6 @@ var nonTransformedProperties = {
   'id': true,
   'label': true,
   'lang': true,
-  'list': true,
   'loop': true,
   'max': true,
   'method': true,


### PR DESCRIPTION
# Overview

In regards to the issue reported on Friday, the 'list' property was not setting properly.
This fixes that issue by moving it from a property setting to an attribute one.

## Details

HTMLInputElement.prototype.list is a property, but it's a read only reference to the datalist element referenced by the attribute value. Attempting to set the property directly fail, but `.setAttribute('list', '...')` works as expected.

By removing list from the whitelist in process_properties, it will be treated as an attribute and updated accordingly.

