### PR TITLE
Fix for Component warning in Collections

### DIFF
--- a/adaptors/backbone/base_collection.js
+++ b/adaptors/backbone/base_collection.js
@@ -185,7 +185,8 @@ if (typeof TUNGSTENJS_DEBUG_MODE !== 'undefined') {
         isParent: true,
         getChildren: true,
         getDebugName: true,
-        toString: true
+        toString: true,
+        _onModelEvent: true
       };
       var getFunctions = require('../shared/get_functions');
       return getFunctions(trackedFunctions, getTrackableFunction, this, BaseCollection.prototype, blacklist);

--- a/adaptors/backbone/component_widget.js
+++ b/adaptors/backbone/component_widget.js
@@ -2,12 +2,18 @@
 
 var _ = require('underscore');
 var errors = require('../../src/utils/errors');
-
 var modelFunctionsToMap = ['trigger', 'set', 'get', 'has', 'doSerialize', 'save', 'fetch', 'sync', 'validate', 'isValid'];
 var modelFunctionsToDummy = ['on', 'off', 'listenTo'];
 
+module.exports = ComponentWidget;
+
 var getDummyFunction = function(fn) {
   return function() {
+    // Collection._addReference will bind all events to its models
+    // to avoid spamming errors about this, handle the specific case
+    if (arguments.length === 3 && arguments[0] === 'all' && arguments[1] === require('./base_collection').prototype._onModelEvent) {
+      return;
+    }
     errors.componentFunctionMayNotBeCalledDirectly(fn);
   };
 };
@@ -200,5 +206,3 @@ if (typeof TUNGSTENJS_DEBUG_MODE !== 'undefined') {
     return '<span class="js-view-list-item u-clickable u-underlined" data-id="' + name + '">[' + name + ']</span>';
   };
 }
-
-module.exports = ComponentWidget;

--- a/test/adaptors/backbone/component_widget_spec.js
+++ b/test/adaptors/backbone/component_widget_spec.js
@@ -205,4 +205,29 @@ describe('component_widget public api', function() {
       expect(ctx.view).to.equal(expectedView);
     });
   });
+  describe('errors', function() {
+    it('should warn when invoking its .on() method', function() {
+      const errors = require('../../../src/utils/errors');
+      const Model = require('../../../adaptors/backbone/base_model');
+      spyOn(errors, 'componentFunctionMayNotBeCalledDirectly');
+      var ViewConstructor = function() {};
+      var model = new Model({});
+      var component = new ComponentWidget(ViewConstructor, model);
+      component.on('all', function() {});
+      jasmineExpect(errors.componentFunctionMayNotBeCalledDirectly).toHaveBeenCalled();
+    });
+    it('should not warn when its .on() method is invoked by a Collection', function() {
+      const errors = require('../../../src/utils/errors');
+      const Model = require('../../../adaptors/backbone/base_model');
+      const Collection = require('../../../adaptors/backbone/base_collection');
+      spyOn(errors, 'componentFunctionMayNotBeCalledDirectly');
+      var ViewConstructor = function() {};
+      var model = new Model({});
+      var component = new ComponentWidget(ViewConstructor, model);
+      var collection = new Collection([]);
+      collection.add(component);
+      collection.remove(component);
+      jasmineExpect(errors.componentFunctionMayNotBeCalledDirectly).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
# Overview

Adds an exception for the Component.on/off methods being called directly by Collections.

## Details

Rather than bind/unbind or override addReference/removeReference, this adds an exception to the error messaging to ignore the arguments passed by these methods