### PR TITLE
Serialize non relation components

### DIFF
--- a/adaptors/backbone/base_model.js
+++ b/adaptors/backbone/base_model.js
@@ -699,7 +699,7 @@ BaseModel.prototype.toJSON = function() {
     // Skip any derived or session properties
     if (!derived[key] && !session[key]) {
       // Recursively serialize any set relations
-      if (relations[key] && typeof val.doSerialize === 'function') {
+      if ((relations[key] && typeof val.doSerialize === 'function') || (val && ComponentWidget.isComponent(val))) {
         data[key] = val.doSerialize();
       } else {
         data[key] = val;


### PR DESCRIPTION
# Overview

Serialize component objects when `Model.toJSON` is invoked, even when a relation is not set

## Details

By checking explicitly for Component objects when a relation is not set for a value, Components can be serialized outside of non-relation child models.

By adding explicit tests for serializing child models with and without relations, we can ensure that this change does not affect that dynamic while allowing Components to be dehydrated to raw data.