### PR TITLE
Fix for serializing models with a "length" property

### DIFF
--- a/adaptors/backbone/base_model.js
+++ b/adaptors/backbone/base_model.js
@@ -695,7 +695,8 @@ BaseModel.prototype.toJSON = function() {
   var session = _.invert(_.result(this, 'session') || []);
 
   var data = {};
-  _.each(attrs, function(val, key) {
+  for (var key in attrs) {
+    var val = attrs[key];
     // Skip any derived or session properties
     if (!derived[key] && !session[key]) {
       // Recursively serialize any set relations
@@ -705,7 +706,7 @@ BaseModel.prototype.toJSON = function() {
         data[key] = val;
       }
     }
-  });
+  }
   return data;
 };
 

--- a/test/adaptors/backbone/base_model_spec.js
+++ b/test/adaptors/backbone/base_model_spec.js
@@ -112,6 +112,14 @@ describe('base_model.js constructed api', function() {
       expect(serialized.foo).not.to.be.instanceOf(ComponentWidget);
       expect(serialized.foo).to.deep.equal(componentData);
     });
+    it('should serialize models with a length property', function() {
+      var BaseBackboneModel = BackboneAdaptor.Backbone.Model;
+      var data = {length: 2};
+      var backboneModel = new BaseBackboneModel(data);
+      var tungstenModel = new BaseModel(data);
+      expect(backboneModel.toJSON()).to.deep.equal(data);
+      expect(tungstenModel.toJSON()).to.deep.equal(data);
+    });
   });
   describe('doSerialize', function() {
     it('should be a function', function() {


### PR DESCRIPTION
# Overview

`_.each` handles array-like objects as arrays, which breaks serialization for some models

## Details

Since `_.each` is used within `.toJSON`, any model with a numeric length property between 0 and 2^53 is treated as an array and the serialized output is unexpected.

By changing the `_.each` to a for/in loop, we avoid this issue as we can be certain that Model.attributes is an object not an array