### PR TITLE
Handling for component reposition

### DIFF
--- a/adaptors/backbone/component_widget.js
+++ b/adaptors/backbone/component_widget.js
@@ -130,6 +130,9 @@ ComponentWidget.prototype.isComponent = true;
  * @return {Element} DOM node with the child view attached
  */
 ComponentWidget.prototype.init = function init() {
+  if (this.view) {
+    this.previousView = this.view;
+  }
   this.view = new this.ViewConstructor({
     template: this.template,
     model: this.model,
@@ -144,10 +147,13 @@ ComponentWidget.prototype.init = function init() {
  * Pass through to the view's destroy method
  */
 ComponentWidget.prototype.destroy = function destroy() {
-  if (this.view && this.view.destroy) {
-    this.isInitialized = false;
-    this.view.destroy();
+  var key = this.previousView ? 'previousView' : 'view';
+  var view = this[key];
+  if (view && typeof view.destroy === 'function') {
+    view.destroy();
   }
+  this.isInitialized = false;
+  this[key] = null;
 };
 
 /**


### PR DESCRIPTION
# Overview

Handle cases when a Component's `destroy` and `init` functions are called in the same cycle.

## Details

When a component is repositioned, it can have its `destroy` and `init` functions run in the same patch cycle. This caused a situation where a view that should've been destroyed was left orphaned and the view on the component was inactive. This change allows views to be properly handled so that the correct view is destroyed and none are orphaned.