### PR TITLE
Adds `isNode` check.

### DIFF
--- a/plugins/tungsten-event-intent/index.js
+++ b/plugins/tungsten-event-intent/index.js
@@ -1,3 +1,5 @@
+/* eslint-env browser */
+
 /**
  * Module to handle "intent" delay on events
  */

--- a/plugins/tungsten-event-mouseenter/index.js
+++ b/plugins/tungsten-event-mouseenter/index.js
@@ -1,7 +1,21 @@
+/* eslint-env browser */
+
 /**
  * Module to handle the shimming in delegated mouseenter events
  */
 'use strict';
+
+
+/**
+ * Check if passed object is a valid DOM Node
+ * @param  {Object}  node  object to be validated
+ * @return {Boolean}       whether object is a DOM node
+ */
+function isNode(node) {
+  return typeof Node === 'object' ? node instanceof Node :
+    node && typeof node === 'object' && typeof node.nodeType === 'number' &&
+    typeof node.nodeName === 'string';
+}
 
 /**
  * Fallback contains check from http://stackoverflow.com/a/6131052
@@ -10,6 +24,10 @@
  * @return {Boolean}           Whether container contains maybe
  */
 function contains(container, maybe) {
+  if (!isNode(container) || !isNode(maybe)) {
+    return false;
+  }
+
   // 16 is for a nodeType constant: window.Node.DOCUMENT_POSITION_CONTAINED_BY,
   // but the window.Node object is not available in IE8
   return container.contains ? container.contains(maybe) :

--- a/plugins/tungsten-event-mouseenter/index.js
+++ b/plugins/tungsten-event-mouseenter/index.js
@@ -5,7 +5,6 @@
  */
 'use strict';
 
-
 /**
  * Check if passed object is a valid DOM Node
  * @param  {Object}  node  object to be validated

--- a/test/plugins/tungsten-event-mouseenter/index_spec.js
+++ b/test/plugins/tungsten-event-mouseenter/index_spec.js
@@ -1,5 +1,5 @@
 'use strict';
-var mouseenterleaveBind = require('../../../plugins/tungsten-event-mouseenter');
+var mouseEnterLeaveBind = require('../../../plugins/tungsten-event-mouseenter');
 describe('mouseenter_and_mouseleave_events', function() {
   var elem, otherElem, handler, obj;
   beforeEach(function() {
@@ -23,13 +23,27 @@ describe('mouseenter_and_mouseleave_events', function() {
         });
       };
       spyOn(obj, 'bindEventFn').and.callThrough();
-      mouseenterleaveBind(elem, 'mouseenter', '.js-foo', handler, {}, obj.bindEventFn);
+      mouseEnterLeaveBind(elem, 'mouseenter', '.js-foo', handler, {}, obj.bindEventFn);
       jasmineExpect(obj.bindEventFn).toHaveBeenCalledWith(elem, 'mouseover', '.js-foo', jasmine.any(Function), {});
     });
     it('should not call bindVirtualEvent when event is not mouseenter event', function() {
       var spy = jasmine.createSpy('spy');
-      mouseenterleaveBind(elem, 'notmouseenter', '.js-foo', handler, {}, spy);
+      mouseEnterLeaveBind(elem, 'notmouseenter', '.js-foo', handler, {}, spy);
       jasmineExpect(spy).not.toHaveBeenCalled();
+    });
+    it('should not call handler function when currentTarget is not a DOM node', function() {
+      obj.bindEventFn = function(el, eventName, selector, method) {
+        method({
+          currentTarget: {},
+          target: elem,
+          originalEvent: {
+            relatedTarget: otherElem
+          }
+        });
+      };
+      handler = jasmine.createSpy('handler');
+      mouseEnterLeaveBind(elem, 'mouseenter', '.js-foo', handler, {}, obj.bindEventFn);
+      jasmineExpect(handler).not.toHaveBeenCalled();
     });
 
   });
@@ -46,13 +60,27 @@ describe('mouseenter_and_mouseleave_events', function() {
         });
       };
       spyOn(obj, 'bindEventFn').and.callThrough();
-      mouseenterleaveBind(elem, 'mouseleave', '.js-foo', handler, {}, obj.bindEventFn);
+      mouseEnterLeaveBind(elem, 'mouseleave', '.js-foo', handler, {}, obj.bindEventFn);
       jasmineExpect(obj.bindEventFn).toHaveBeenCalledWith(elem, 'mouseout', '.js-foo', jasmine.any(Function), {});
     });
     it('should not call bindVirtualEvent when event is not mouseleave event', function() {
       var spy = jasmine.createSpy('spy');
-      mouseenterleaveBind(elem, 'notmouseleave', '.js-foo', handler, {}, spy);
+      mouseEnterLeaveBind(elem, 'notmouseleave', '.js-foo', handler, {}, spy);
       jasmineExpect(spy).not.toHaveBeenCalled();
+    });
+    it('should not call handler function when currentTarget is not a DOM node', function() {
+      obj.bindEventFn = function(el, eventName, selector, method) {
+        method({
+          currentTarget: {},
+          target: elem,
+          originalEvent: {
+            relatedTarget: otherElem
+          }
+        });
+      };
+      handler = jasmine.createSpy('handler');
+      mouseEnterLeaveBind(elem, 'mouseleave', '.js-foo', handler, {}, obj.bindEventFn);
+      jasmineExpect(handler).not.toHaveBeenCalled();
     });
 
   });


### PR DESCRIPTION
# Overview

Adds `isNode` check for nodes `A` and `B ` when checking if `A.contains(B)`.
This should prevent `IE10` errors for hover events, for more details please refer to `pt:7458101`.

## Details

Function was tested on:

*Windows 7*
- `IE 8`
- `IE 9`
- `IE 10`
- `IE 11`
- `Safari 4`
- `Safari 5.1`
- `Firefox 42`
- `Firefox 49`

*OSX Sierra*
- `Safari 10`
- `Opera 32`
- `Opera 40`
- `Chrome 47`
- `Chrome 56`

*iOS*
- `iPhone 4, iOS 4, Safari`
- `iPhone 6, iOS 8, Safari`
- `iPhone 7, iOS 10, Safari`

*Android*
- ` Galaxy S2, Android 2.3`
- `Nexus 6p, Android 7` 






