### PR TITLE
Removes `.../precompile/tungsten_template/inline.js` from Jasmine helpers array.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,10 @@
 {
-  "plugins": ["transform-es2015-block-scoping", "transform-es2015-constants", "transform-es2015-arrow-functions", "transform-es2015-shorthand-properties", "transform-es2015-parameters", "transform-es2015-template-literals"]
+  "plugins": [
+    "transform-es2015-block-scoping",
+    "transform-es2015-constants",
+    "transform-es2015-arrow-functions",
+    "transform-es2015-shorthand-properties",
+    "transform-es2015-parameters",
+    "transform-es2015-template-literals"
+  ]
 }

--- a/test/jasmine.js
+++ b/test/jasmine.js
@@ -44,8 +44,7 @@ jasmine.loadConfig({
     './testbuild.debug.js'
   ],
   'helpers': [
-    'environment.js',
-    '../precompile/tungsten_template/inline.js'
+    'environment.js'
   ]
 });
 jasmine.execute();


### PR DESCRIPTION
# Overview

Removes `../precompile/tungsten_template/inline.js` file from Jasmine helpers array.

## Details

This is what was happening in `test/jasmine.js` file:

In `jasmine.loadConfig` function we have `helpers` array and pass `.../precompile/tungsten_template/inline.js` file. This file then starts pulling (`require`) it's dependencies that didn't go through `Babel`.

Since all test pass fine without this helper, I think it's safe to remove it from `helpers` array.