### PR TITLE
Setting a model relation with a model

### DIFF
--- a/adaptors/backbone/base_model.js
+++ b/adaptors/backbone/base_model.js
@@ -416,7 +416,7 @@ BaseModel.prototype.setRelation = function(attr, val, options) {
     }
 
     if (relation && relation instanceof Backbone.Model) {
-      relation.set(val);
+      relation.set(val && val.toJSON ? val.toJSON() : val);
       return relation;
     }
 

--- a/test/adaptors/backbone/base_model_spec.js
+++ b/test/adaptors/backbone/base_model_spec.js
@@ -191,6 +191,30 @@ describe('base_model.js constructed api', function() {
       expect(testModel.get('collection').pluck('id').join('&')).to.equal('2&3&4');
       expect(testModel.get('collection').pluck('n').join('&')).to.equal('2&3&4');
     });
+    it('should update a nested model', function() {
+      var TestModel = BaseModel.extend({
+        relations: {
+          model: BaseModel
+        }
+      });
+      var testModel = new TestModel({
+        model: { id: 1, n: 1 }
+      });
+      expect(testModel.get('model')).to.be.instanceof(BaseModel);
+      expect(testModel.get('model').toJSON()).to.deep.equal({ id: 1, n: 1 });
+
+      testModel.set({
+        model: { id: 2 }
+      });
+      expect(testModel.get('model')).to.be.instanceof(BaseModel);
+      expect(testModel.get('model').toJSON()).to.deep.equal({ id: 2, n: 1 });
+
+      testModel.set({
+        model: new BaseModel({ n: 2 })
+      });
+      expect(testModel.get('model')).to.be.instanceof(BaseModel);
+      expect(testModel.get('model').toJSON()).to.deep.equal({ id: 2, n: 2 });
+    });
   });
   describe('trigger', function() {
     it('should be a function', function() {

--- a/test/adaptors/backbone/base_model_spec.js
+++ b/test/adaptors/backbone/base_model_spec.js
@@ -180,6 +180,16 @@ describe('base_model.js constructed api', function() {
       });
       expect(testModel.get('collection').pluck('id').join('&')).to.equal('2&3&4');
       expect(testModel.get('collection').pluck('n').join('&')).to.equal('1&2&3');
+
+      testModel.set({
+        collection: new BaseCollection([
+          { id: 2, n: 2 },
+          { id: 3, n: 3 },
+          { id: 4, n: 4 }
+        ])
+      });
+      expect(testModel.get('collection').pluck('id').join('&')).to.equal('2&3&4');
+      expect(testModel.get('collection').pluck('n').join('&')).to.equal('2&3&4');
     });
   });
   describe('trigger', function() {


### PR DESCRIPTION
# Overview

There's a bug right now that if you pass a constructed model into a property set to a relation, the data gets all of the model properties instead of the data for it. This serializes the model so that the data is properly set before passing into the sub-model's set function.