### PR TITLE
Default document bound touch and pointer events to have passive listeners

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,8 @@
   },
   "env": {
     "es6": true,
-    "shared-node-browser": true
+    "browser": true,
+    "node": true
   },
   "globals": {
     "require": true,

--- a/plugins/tungsten-event-touch/index.js
+++ b/plugins/tungsten-event-touch/index.js
@@ -25,6 +25,8 @@
  * THE SOFTWARE.
  */
 'use strict';
+var featureDetect = require('../../src/utils/feature_detect');
+var supportsPassive = featureDetect.supportsPassiveEventListeners();
 
 if (typeof document.createEvent === 'function') {
   // some helpers borrowed from https://github.com/WebReflection/ie-touch
@@ -57,7 +59,11 @@ if (typeof document.createEvent === 'function') {
       i = eventsArray.length;
 
     while (i--) {
-      document.addEventListener(eventsArray[i], callback, false);
+      document.addEventListener(
+        eventsArray[i],
+        callback,
+        supportsPassive ? {passive: true} : false
+      );
     }
   };
   var getPointerEvent = function(event) {

--- a/src/utils/feature_detect.js
+++ b/src/utils/feature_detect.js
@@ -17,5 +17,19 @@ module.exports = {
       return false;
     }
     return /Edge\/|Trident\/|MSIE/i.test(window.navigator.userAgent);
+  },
+  // Taken from https://github.com/Modernizr/Modernizr/blob/master/feature-detects/dom/passiveeventlisteners.js
+  supportsPassiveEventListeners: function() {
+    var supportsPassiveOption = false;
+    try {
+      var opts = Object.defineProperty({}, 'passive', {
+        get: function() {
+          supportsPassiveOption = true;
+        }
+      });
+      window.addEventListener('test', null, opts);
+      // eslint-disable-next-line
+    } catch (e) {};
+    return supportsPassiveOption;
   }
 };

--- a/test/src/utils/feature_detect_spec.js
+++ b/test/src/utils/feature_detect_spec.js
@@ -161,7 +161,7 @@ describe('feature_detect.js public API', function() {
 
     it('should not pass when an error was thrown', function() {
       window.addEventListener = function(type, listener, options) {
-        if (object.prototype.toString.call(options) === '[object Object]') {
+        if (Object.prototype.toString.call(options) === '[object Object]') {
           throw new Error();
         }
       };

--- a/test/src/utils/feature_detect_spec.js
+++ b/test/src/utils/feature_detect_spec.js
@@ -140,4 +140,32 @@ describe('feature_detect.js public API', function() {
       expect(featureDetect.isIE()).to.be.false;
     });
   });
+
+  describe('supportsPassiveEventListeners', function() {
+    var originalAddEventListener = window.addEventListener;
+
+    afterEach(function() {
+      window.addEventListener = originalAddEventListener;
+    });
+
+    it('should be a function', function() {
+      expect(featureDetect.supportsPassiveEventListeners).to.be.a('function');
+    });
+
+    it('should pass when passive property was checked on options object', function() {
+      window.addEventListener = function(type, listener, options) {
+        options && options.passive;
+      };
+      expect(featureDetect.supportsPassiveEventListeners()).to.be.true;
+    });
+
+    it('should not pass when an error was thrown', function() {
+      window.addEventListener = function(type, listener, options) {
+        if (object.prototype.toString.call(options) === '[object Object]') {
+          throw new Error();
+        }
+      };
+      expect(featureDetect.supportsPassiveEventListeners()).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
# Overview

Defaults document bound touch and pointer events to have passive listeners, this will not affect how our virtual / synthetic events are dispatched.
 
We got user reports showing "event was delayed for X ms due to main thread being busy" while mobile page was loading and users were trying to scroll.

Code change I propose shouldn't change anything for devices not supporting `passive event listeners`.

This will affect only relatively new Chrome Desktop, FF and Android devices latest (1-2) major versions that support `passive event listeners`. 

Latest Chrome Mobile and Desktop browsers know how to do this out of the box, see **Details** for more info.

## Feature support for passive event listeners

* FF 49+
* Chrome 51+
* Opera 41+
* Android Browser (WebView) 53+
* Android Chrome 54+
* Opera mini - not supported
* **iOS Safari - not supported**
* **Safari TP+**
* **IE - not supported**

Taken from [caniuse].

## Details

Turns out Chrome Dev Team already enabled **Touch Event Listeners Passive Default During Fling**, plus in stable Chrome Desktop (55) all document bound listeners are automatically marked as `passive` if not specified otherwise.

### Important Chrome Changes

1. **Touch Event Listeners Passive Default During Fling (Mobile and Desktop ![chrome] 54 opt-out)**
Forces touchstart, and first touchmove per scroll event listeners during fling to be treated as passive. #passive-event-listeners-due-to-fling
https://www.chromestatus.com/features/5707400183021568

2. **Document Level Event Listeners Passive Default (Mobile and Desktop ![chrome] 54 opt-in)**
Forces touchstart, and touchmove event listeners on document level targets (which haven't requested otherwise) to be treated as passive. #document-passive-event-listeners
https://www.chromestatus.com/features/5093566007214080

3. **Passive Event Listener Override (Mobile and Desktop ![chrome] 54 opt-in)**
Forces touchstart, touchmove, mousewheel and wheel event listeners (which haven't requested otherwise) to be treated as passive. This will break touch/wheel behavior on some websites but is useful for demonstrating the potential performance benefits of adopting passive event listeners. #passive-listener-default

## Testing

Manually tested with: 

1. Android Chrome 54;
2. Android Webview 53;
3. Chrome 52, 55-57;
4. Chromium 46.

Not sure if `plugin-event-touch` can be covered with tests, we use [tocca.js] and rely on it's coverage.
Feature test for passive event listeners was taken from [modernizr] and there's nothing to test.

[chrome]: https://www.google.com/images/icons/product/chrome-16.png "Chrome"
[caniuse]: http://caniuse.com/#feat=passive-event-listener
[modernizr]: https://github.com/Modernizr/Modernizr/blob/master/feature-detects/dom/passiveeventlisteners.js
[tocca.js]: http://gianlucaguarini.com/Tocca.js/