### PR TITLE
Sourcemaps are generated for main tungsten build and example projects.

### DIFF
--- a/examples/base_webpack.config.js
+++ b/examples/base_webpack.config.js
@@ -29,10 +29,14 @@ module.exports = function (root, options) {
       }
     },
     module: {
+      preLoaders: [
+        { test: /\.js$/, loader: 'source-map-loader' }
+      ],
       loaders: [
         {test: /\.mustache$/, loader: path.join(__dirname, '../precompile/tungsten_template')},
         {test: /\.js$/, loader: 'babel', exclude: /node_modules/}
       ]
-    }
+    },
+    devtool: '#source-map'
   };
 };

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "opener": "^1.4.1",
     "publish-please": "^1.1.0",
     "semver": "^5.1.0",
+    "source-map-loader": "^0.1.5",
     "webpack": "2.1.0-beta.4",
     "webpack-dev-middleware": "1.5.1"
   },

--- a/webpack.plugins.js
+++ b/webpack.plugins.js
@@ -26,5 +26,6 @@ module.exports = webpackSettings.compileSource({
     libraryTarget: 'umd',
     library: ['tungsten', 'plugins', 'event', '[name]'],
     path: __dirname + '/dist'
-  }
+  },
+  devtool: 'source-map'
 });

--- a/webpack.standalone.js
+++ b/webpack.standalone.js
@@ -32,7 +32,11 @@ module.exports = function(options) {
       modules: [path.join(__dirname, 'node_modules')]
     },
     module: {
+      preLoaders: [
+        { test: /\.js$/, loader: 'source-map-loader' }
+      ],
       loaders: []
-    }
+    },
+    devtool: 'source-map'
   }, options.dev, options.test);
 };


### PR DESCRIPTION
# Source Maps
Previously, no source maps were generated as part of the webpack build process. Now they are.

## Details
Added `devtool: 'source-map'` in order to output source maps. Additionally, added the `source-map-loader` preloader so that the source maps of dependencies will also be processed. 

I think this is a pure win. I don't see a downside to including source maps. I've tested the example projects. Source maps are visible and useable in chrome dev tools. I haven't verified that the source maps are working for plugins. I believe these are not used in the example projects

The _dist_ folder is showing up in the sources, which isn't quite right. Dist is a destination folder. I'd like to fix this, but I think just getting source maps working in general is a big win and don't want to hold things up while I look for a solution to this relatively small issue.
