### PR TITLE
Fixing svg attributes hooks

### DIFF
--- a/src/template/process_svg_namespaces.js
+++ b/src/template/process_svg_namespaces.js
@@ -8,7 +8,7 @@ module.exports = function processSvgNamespace(properties) {
   }
 
   let namespacedAttrs = {};
-  let props = _.create(properties);
+  let props = _.extend({}, properties);
   props.attributes = namespacedAttrs;
 
   let attributes = properties.attributes;

--- a/src/template/process_svg_namespaces.js
+++ b/src/template/process_svg_namespaces.js
@@ -1,20 +1,28 @@
+const _ = require('underscore');
 const svgAttributeNamespace = require('virtual-dom/virtual-hyperscript/svg-attribute-namespace');
 const AttributeHook = require('virtual-dom/virtual-hyperscript/hooks/attribute-hook');
 
-module.exports = function processSvgNamespace(attributes) {
-  if (!attributes) {
-    return attributes;
+module.exports = function processSvgNamespace(properties) {
+  if (!properties || !properties.attributes) {
+    return properties;
   }
 
-  let namespaced = {};
+  let namespacedAttrs = {};
+  let props = _.create(properties);
+  props.attributes = namespacedAttrs;
+
+  let attributes = properties.attributes;
   for (let attrName in attributes) {
-    let namespace = svgAttributeNamespace(attrName);
-    if (namespace) {
-      namespaced[attrName] = new AttributeHook(namespace, attributes[attrName]);
-    } else {
-      namespaced[attrName] = attributes[attrName];
+    if (attrName !== 'namespace') {
+      let namespace = svgAttributeNamespace(attrName);
+      if (namespace) {
+        // Hooks need to be moved to the top object to be processed
+        props[attrName] = new AttributeHook(namespace, attributes[attrName]);
+      } else {
+        namespacedAttrs[attrName] = attributes[attrName];
+      }
     }
   }
 
-  return namespaced;
+  return props;
 };

--- a/src/template/stacks/vdom.js
+++ b/src/template/stacks/vdom.js
@@ -37,7 +37,7 @@ VdomStack.prototype.processObject = function(obj) {
 
     // if we're rendering an element with a namespace, check if any attributes require namespacing
     if (obj.properties.namespace) {
-      obj.properties.attributes = processSvgNamespaces(obj.properties.attributes);
+      obj.properties = processSvgNamespaces(obj.properties);
     }
 
     return tungsten.createVNode(obj.tagName, obj.properties, obj.children);


### PR DESCRIPTION
# Overview

Actually fixing the SVG namespace attribute issue. Hooks needed to be pulled up from `properties.attributes` to `properties`.

## Details

Tested using the svg example project, was able to reproduce the reported issue and then saw it fixed with the attribute's `namespaceURI` property set appropriately